### PR TITLE
Add `--pretty` option to render preview output sheets with aligned borders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "tsvkit"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsvkit"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -242,11 +242,12 @@ Inspect `.xlsx` workbooks, preview sheets, export ranges as TSV, or assemble new
   tsvkit excel --sheets reports.xlsx
   ```
 
-- **Preview** the first rows of every sheet (header + N rows). Use `-s` to focus on one sheet, `-n` to change the window, `--formulas` to show Excel formulas instead of values, and `--dates raw|excel|iso` to control date rendering (`iso` is the default):
+- **Preview** the first rows of every sheet (header + N rows). Use `-s` to focus on one sheet, `-n` to change the window, `--formulas` to show Excel formulas instead of values, `--dates raw|excel|iso` to control date rendering (`iso` is the default), and `--pretty` to render the preview with aligned borders:
 
   ```bash
   tsvkit excel --preview reports.xlsx -n 5 -s Summary
   tsvkit excel --preview reports.xlsx --formulas --dates raw
+  tsvkit excel --preview reports.xlsx --pretty
   ```
 
 - **Dump** a sheet (or subset) to TSV. Columns accept names, indices, or Excel letters/ranges (e.g. `A:C,Expr`). Rows accept 1-based indices or inclusive ranges (`1,10:20,100:`). `--na` replaces blanks, `--escape-*` makes TSV-safe output, and the same `--values/--formulas` + `--dates` controls apply:

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -84,7 +84,7 @@ pub fn run(args: PrettyArgs) -> Result<()> {
     render_table(header, rows)
 }
 
-fn render_table(header: Option<Vec<String>>, rows: Vec<Vec<String>>) -> Result<()> {
+pub fn render_table(header: Option<Vec<String>>, rows: Vec<Vec<String>>) -> Result<()> {
     let mut writer = BufWriter::new(io::stdout().lock());
 
     let column_count = compute_column_count(&header, &rows);


### PR DESCRIPTION
Add `--pretty` option to render preview output sheets with aligned borders.
Each sheet will be displayed in pretty style like `tsvkit pretty`.