### PR TITLE
Support open-ended selectors in slice and Excel dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ tsvkit pivot -i gene -c sample_id -v expression examples/expression.tsv
 
 ### `slice`
 
-Take specific rows (1-based indices or ranges).
+Take specific rows (1-based indices or ranges, including open-ended forms like `:10`, `10:`, or even `:` for everything).
 
 ```bash
 tsvkit slice -r 1,4:5 examples/samples.tsv
@@ -255,7 +255,7 @@ Inspect `.xlsx` workbooks, preview sheets, export ranges as TSV, or assemble new
   tsvkit excel --preview reports.xlsx --pretty
   ```
 
-- **Dump** a sheet (or subset) to TSV. Columns accept names, indices, or Excel letters/ranges (e.g. `A:C,Expr`). Rows accept 1-based indices or inclusive ranges (`1,10:20,100:`). `--na` replaces blanks, `--escape-*` makes TSV-safe output, and the same `--values/--formulas` + `--dates` controls apply:
+- **Dump** a sheet (or subset) to TSV. Columns accept names, indices, or Excel letters/ranges (e.g. `A:C,Expr`, `:C`, `C:`). Rows accept 1-based indices or inclusive ranges (`1,10:20,:25,100:`). `--na` replaces blanks, `--escape-*` makes TSV-safe output, and the same `--values/--formulas` + `--dates` controls apply:
 
   ```bash
   tsvkit excel --dump reports.xlsx -s Data -f 'A:C,Expr' -r 1:100 --na NA > data.tsv


### PR DESCRIPTION
## Summary
- allow `tsvkit slice` row specifications to use open-ended forms such as `:10`, `10:`, and `:`
- teach `tsvkit excel --dump` to handle open-ended column selectors while guarding against empty sheets
- document the expanded selector syntax in the README

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e01f424e14832a942bb54f7a8ce240