### PR TITLE
Enhance summarize stats and selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "tsvkit"
-version = "0.8.4"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "calamine",


### PR DESCRIPTION
## Summary
- add support for open-ended column ranges in `tsvkit summarize -s` selectors
- implement additional summary operations (absmin/absmax, trimmean, iqr, rand, unique, collapse, countunique, antimode, prod, entropy, argmin/argmax, etc.)
- refactor aggregation helpers and add unit tests for the new behaviour

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e2b6e841e8832aa8ad781d5e88e9d0