### PR TITLE
Support tail selectors and brace quoting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "tsvkit"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "calamine",

--- a/README.md
+++ b/README.md
@@ -118,11 +118,16 @@ Selectors are reused in `cut`, `filter`, `join`, `mutate`, `summarize`, and othe
 | ------- | ------- | ------- |
 | `name` | Column by header name. | `sample_id,purity` |
 | `index` | 1-based column index. | `1,4,9` |
+| `-index` | Column counted from the end (1 = last). | `-1,-2` |
 | `start:end` | Inclusive range by name or index. Supports open ends. | `IL6:IL10`, `2:5`, `:IL10`, `IL6:` |
 | `:` | Select every column in order. | `-f ':'` |
 | `mixed` | Combine names, indices, and ranges. | `sample_id,3:5,tech` |
 | `multi-file` | Separate selectors for each input with semicolons (primarily `join`). | `sample_id;subject_id` |
 | `range in expressions` | Prefixed with `$` to access a slice of values. | `$IL6:$IL10` |
+
+> Wrap selectors in backticks or braces to treat punctuation literally. For example, ``-f '`IL6:IL10`,`total,reads`'`` or `-f '{IL6:IL10},{total,reads}'` selects columns named `IL6:IL10` and `total,reads` instead of expanding a range or splitting on the comma.
+
+Negative indices are also valid inside ranges: `:-2` selects every column except the final two, while `-3:` keeps the last three columns.
 
 Anywhere you access column *values* inside an expression, prefix the selector with `$` (`$purity`, `$1`, `$IL6:$IL10`).
 
@@ -140,13 +145,15 @@ The same expression language powers `filter -e`, `mutate -e name=EXPR`, and rege
 
 | Symbol / keyword | Description | Works on |
 | ---------------- | ----------- | -------- |
-| `+ - * /` | Arithmetic operators. | Numbers |
+| `+ - * / ^` | Arithmetic operators (`^` is exponentiation, right-associative). | Numbers |
 | `== != < <= > >=` | Comparisons. | Numbers or strings |
 | `&` / `and` | Logical AND. | Booleans |
 | `|` / `or` | Logical OR. | Booleans |
 | `!` / `not` | Logical negation. | Booleans |
 | `~` | Regex match. Right-hand side can be literal text or a `$range`. | Strings |
 | `!~` | Regex does *not* match. | Strings |
+
+> Reference columns whose names contain operators or punctuation with `${column-name}` inside expressions (e.g. `${dna-} - $rna_ug`). This prevents the parser from treating the characters as arithmetic.
 
 **Numeric helper functions**
 
@@ -356,7 +363,7 @@ tsvkit pivot -i gene -c sample_id -v expression examples/expression.tsv
 ```
 
 ### `slice`
-Take specific rows (1-based indices or ranges, including open-ended forms like `:10`, `10:`, or even `:` for everything).
+Take specific rows (1-based indices or ranges, including open-ended forms like `:10`, `10:`, or even `:` for everything). Negative indices count from the end, so `:-2` emits every row except the final two and `-3:` keeps the last three rows.
 
 ```bash
 tsvkit slice -r 1,4:5 examples/samples.tsv

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -5,7 +5,9 @@ use anyhow::{Context, Result, bail};
 use regex::Regex;
 
 use crate::aggregate::{AggregateKind, evaluate_row_aggregate, try_parse_aggregate_kind};
-use crate::common::{ColumnSelector, parse_selector_list, resolve_selectors};
+use crate::common::{
+    ColumnSelector, parse_selector_list, parse_single_selector, resolve_selectors,
+};
 
 #[derive(Debug, Clone)]
 pub enum Expr {
@@ -45,6 +47,7 @@ pub enum BinaryOp {
     Sub,
     Mul,
     Div,
+    Pow,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -105,6 +108,7 @@ enum Token {
     Minus,
     Star,
     Slash,
+    Caret,
 }
 
 pub fn parse_expression(input: &str) -> Result<Expr> {
@@ -320,6 +324,14 @@ where
                             empty_eval()
                         } else {
                             numeric_eval(a / b)
+                        }
+                    }
+                    BinaryOp::Pow => {
+                        let value = a.powf(b);
+                        if value.is_finite() {
+                            numeric_eval(value)
+                        } else {
+                            empty_eval()
                         }
                     }
                 },
@@ -623,6 +635,52 @@ mod tests {
         ];
         assert!(evaluate(&bound, &row));
     }
+
+    #[test]
+    fn subtraction_without_spaces_between_columns() {
+        let expr = parse_expression("($dna_ug-$rna_ug)>10").unwrap();
+        let headers = vec!["dna_ug".to_string(), "rna_ug".to_string()];
+        let bound = bind_expression(expr, &headers, false).unwrap();
+        let row = vec!["25.0".to_string(), "12.0".to_string()];
+        assert!(evaluate(&bound, &row));
+    }
+
+    #[test]
+    fn subtraction_with_space_after_minus() {
+        let expr = parse_expression("($dna_ug- $rna_ug)>10").unwrap();
+        let headers = vec!["dna_ug".to_string(), "rna_ug".to_string()];
+        let bound = bind_expression(expr, &headers, false).unwrap();
+        let row = vec!["22.0".to_string(), "5.0".to_string()];
+        assert!(evaluate(&bound, &row));
+    }
+
+    #[test]
+    fn exponentiation_operator_supported() {
+        let expr = parse_value_expression("$dna_ug^2").unwrap();
+        let headers = vec!["dna_ug".to_string()];
+        let bound = bind_value_expression(expr, &headers, false).unwrap();
+        let row = vec!["3".to_string()];
+        let eval = eval_value(&bound, &row);
+        assert_eq!(eval.numeric, Some(9.0));
+    }
+
+    #[test]
+    fn exponentiation_is_right_associative() {
+        let expr = parse_value_expression("2^3^2").unwrap();
+        let bound = bind_value_expression(expr, &[], false).unwrap();
+        let row: Vec<String> = Vec::new();
+        let eval = eval_value(&bound, &row);
+        assert_eq!(eval.numeric, Some(512.0));
+    }
+
+    #[test]
+    fn braces_allow_literal_column_names() {
+        let expr = parse_expression("${dna-}").unwrap();
+        let headers = vec!["dna-".to_string()];
+        let bound = bind_expression(expr, &headers, false).unwrap();
+        let row = vec!["value".to_string()];
+        assert!(evaluate(&bound, &row));
+    }
 }
 
 impl<'a> Lexer<'a> {
@@ -722,6 +780,10 @@ impl<'a> Lexer<'a> {
                 self.pos += 1;
                 Ok(Some(Token::Slash))
             }
+            b'^' => {
+                self.pos += 1;
+                Ok(Some(Token::Caret))
+            }
             c if c.is_ascii_digit() || c == b'.' => self.lex_number(),
             c if c.is_ascii_alphabetic() || c == b'_' => {
                 let ident = self.lex_identifier();
@@ -733,6 +795,28 @@ impl<'a> Lexer<'a> {
 
     fn lex_column(&mut self) -> Result<Option<Token>> {
         self.pos += 1;
+        if self.match_char(b'{') {
+            self.pos += 1;
+            let mut value = String::new();
+            let mut escaped = false;
+            while self.pos < self.chars.len() {
+                let c = self.chars[self.pos];
+                self.pos += 1;
+                if escaped {
+                    value.push(c as char);
+                    escaped = false;
+                    continue;
+                }
+                match c {
+                    b'\\' => escaped = true,
+                    b'}' => {
+                        return Ok(Some(Token::Column(ColumnSelector::Name(value))));
+                    }
+                    other => value.push(other as char),
+                }
+            }
+            bail!("unterminated '{{' in column selector");
+        }
         let start = self.pos;
         let mut is_numeric = true;
         let mut has_range_syntax = false;
@@ -763,6 +847,19 @@ impl<'a> Lexer<'a> {
                 if is_numeric && self.pos > start {
                     break;
                 }
+                let mut should_break = false;
+                if self.pos > start {
+                    if let Some(next) = self.peek_non_whitespace(1) {
+                        should_break = matches!(
+                            next,
+                            b'$' | b'(' | b')' | b'+' | b'-' | b'*' | b'/' | b'^' | b'"'
+                        ) || next.is_ascii_digit()
+                            || next == b'.';
+                    }
+                }
+                if should_break {
+                    break;
+                }
                 is_numeric = false;
                 self.pos += 1;
                 continue;
@@ -783,14 +880,9 @@ impl<'a> Lexer<'a> {
             }
             return Ok(Some(Token::Columns(selectors)));
         }
-        if let Ok(idx) = text.parse::<usize>() {
-            if idx == 0 {
-                bail!("column indices use 1-based positions");
-            }
-            Ok(Some(Token::Column(ColumnSelector::Index(idx - 1))))
-        } else {
-            Ok(Some(Token::Column(ColumnSelector::Name(text.to_string()))))
-        }
+        let selector = parse_single_selector(text)
+            .with_context(|| format!("invalid column selector '{}'", text))?;
+        Ok(Some(Token::Column(selector)))
     }
 
     fn lex_string(&mut self) -> Result<Option<Token>> {
@@ -870,6 +962,18 @@ impl<'a> Lexer<'a> {
         self.chars.get(self.pos + offset).copied()
     }
 
+    fn peek_non_whitespace(&self, offset: usize) -> Option<u8> {
+        let mut idx = self.pos + offset;
+        while idx < self.chars.len() {
+            let c = self.chars[idx];
+            if !c.is_ascii_whitespace() {
+                return Some(c);
+            }
+            idx += 1;
+        }
+        None
+    }
+
     fn skip_whitespace(&mut self) {
         while self.pos < self.chars.len() && self.chars[self.pos].is_ascii_whitespace() {
             self.pos += 1;
@@ -934,7 +1038,12 @@ impl Parser {
                 if let Some(next) = self.peek_token() {
                     if matches!(
                         next,
-                        Token::Compare(_) | Token::Plus | Token::Minus | Token::Star | Token::Slash
+                        Token::Compare(_)
+                            | Token::Plus
+                            | Token::Minus
+                            | Token::Star
+                            | Token::Slash
+                            | Token::Caret
                     ) {
                         self.pos = saved_pos;
                         return self.parse_comparison();
@@ -1013,19 +1122,29 @@ impl Parser {
     }
 
     fn parse_term(&mut self) -> Result<ValueExpr> {
-        let mut expr = self.parse_factor()?;
+        let mut expr = self.parse_power()?;
         loop {
             if self.match_token(TokenKind::Star) {
                 self.pos += 1;
-                let rhs = self.parse_factor()?;
+                let rhs = self.parse_power()?;
                 expr = ValueExpr::Binary(BinaryOp::Mul, Box::new(expr), Box::new(rhs));
             } else if self.match_token(TokenKind::Slash) {
                 self.pos += 1;
-                let rhs = self.parse_factor()?;
+                let rhs = self.parse_power()?;
                 expr = ValueExpr::Binary(BinaryOp::Div, Box::new(expr), Box::new(rhs));
             } else {
                 break;
             }
+        }
+        Ok(expr)
+    }
+
+    fn parse_power(&mut self) -> Result<ValueExpr> {
+        let mut expr = self.parse_factor()?;
+        if self.match_token(TokenKind::Caret) {
+            self.pos += 1;
+            let rhs = self.parse_power()?;
+            expr = ValueExpr::Binary(BinaryOp::Pow, Box::new(expr), Box::new(rhs));
         }
         Ok(expr)
     }
@@ -1134,6 +1253,7 @@ impl Parser {
             (TokenKind::Minus, Some(Token::Minus)) => true,
             (TokenKind::Star, Some(Token::Star)) => true,
             (TokenKind::Slash, Some(Token::Slash)) => true,
+            (TokenKind::Caret, Some(Token::Caret)) => true,
             _ => false,
         }
     }
@@ -1175,4 +1295,5 @@ enum TokenKind {
     Minus,
     Star,
     Slash,
+    Caret,
 }


### PR DESCRIPTION
## Summary
- allow CLI column selectors to use backticks or braces for literal names, add negative tail indices, and parse them through the common selector utilities
- enable expressions, row slicing, and Excel row filters to resolve the new selector forms, including buffering when tail-based ranges are requested
- document brace quoting, negative indices, and tail-based row ranges in the README

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e38fd01174832a9723f7a58e757d16