### PR TITLE
Support escaped characters in mutate substitutions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "tsvkit"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "calamine",


### PR DESCRIPTION
## Summary
- allow mutate substitution expressions to recognize escaped separators and common escape sequences
- add coverage ensuring tab and escaped slash handling works as expected
- sync Cargo.lock with the current crate version

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e5316ddd1c832a8b8b6b281b820413