### PR TITLE
Preserve escape sequences in filter string literals

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -189,4 +189,26 @@ mod tests {
         let record = StringRecord::from(vec!["4", "3"]);
         assert!(evaluate(&bound, &record));
     }
+
+    #[test]
+    fn regex_literal_escape_preserved_for_special_characters() {
+        let expr = parse_expression("$1 ~ \"\\\\.\"").unwrap();
+        let headers = vec!["col1".to_string()];
+        let bound = bind_expression(expr, &headers, false).unwrap();
+        let matching = StringRecord::from(vec!["value.with.dot"]);
+        let non_matching = StringRecord::from(vec!["value without dot"]);
+        assert!(evaluate(&bound, &matching));
+        assert!(!evaluate(&bound, &non_matching));
+    }
+
+    #[test]
+    fn regex_literal_escape_handles_vertical_bar() {
+        let expr = parse_expression("$1 ~ \"\\\\|\"").unwrap();
+        let headers = vec!["col1".to_string()];
+        let bound = bind_expression(expr, &headers, false).unwrap();
+        let matching = StringRecord::from(vec!["left|right"]);
+        let non_matching = StringRecord::from(vec!["left/right"]);
+        assert!(evaluate(&bound, &matching));
+        assert!(!evaluate(&bound, &non_matching));
+    }
 }


### PR DESCRIPTION
## Summary
- adjust expression string literal parsing to retain regex escapes while honoring common sequences
- update mutate string literal parsing to mirror the escape handling behavior
- add regression coverage for filter, expression, and mutate escape scenarios

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e53474501c832a9df924c2eb1521a2