### PR TITLE
Add `head` and `transpose` commands, file-template headers, string-case functions, and enhanced mutate substitutions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "tsvkit"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsvkit"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@
   - [`melt`](#melt)
   - [`pivot`](#pivot)
   - [`slice`](#slice)
+  - [`head`](#head)
   - [`pretty`](#pretty)
+  - [`transpose`](#transpose)
   - [`excel`](#excel)
   - [`csv`](#csv)
 - [Additional tips](#additional-tips)
@@ -104,7 +106,9 @@ The list below provides a one-line description of every `tsvkit` subcommand. Eac
 - [`melt`](#melt) — convert wide tables into tidy long form with `variable/value` pairs.
 - [`pivot`](#pivot) — convert long form back to wide with optional fill value for missing cells.
 - [`slice`](#slice) — extract rows by 1-based indices or ranges.
+- [`head`](#head) — preview the first rows as a boxed table (single or multiple files).
 - [`pretty`](#pretty) — render aligned, boxed tables for quick inspection or sharing.
+- [`transpose`](#transpose) — transpose rows and columns.
 - [`excel`](#excel) — inspect, preview, export, or build `.xlsx` workbooks.
 - [`csv`](#csv) — convert delimited text to TSV with custom separators.
 
@@ -174,6 +178,9 @@ List literals use square brackets: `[1,2,3]`, `["case","control"]`, `[IL6:IL10]`
 | `log2(expr)` | Base-2 logarithm |
 | `len(expr)` | Character count using Unicode code points. |
 | `is_na(expr)` | Returns `1` when the expression is blank/`NA`/`NaN`, otherwise `0`. |
+| `upper(expr)` | Convert text to uppercase. |
+| `lower(expr)` | Convert text to lowercase. |
+| `cap(expr)` | Capitalize only the first character. |
 
 Functions accept column references (`abs($purity - 1)`), constants, or subexpressions. Empty or non-numeric values yield blanks.
 
@@ -259,6 +266,28 @@ tsvkit cut --fc sample -f '__base__,1:' examples/qc*.tsv
 ```
 The column name will be "sample" not "__base__" in the output.
 
+`--file-col` now also accepts file-template expressions so injected values can be derived from paths:
+
+```bash
+tsvkit cut --file-col '{base:}' -f '__file__,1:2' examples/qc.tsv
+```
+
+Template tokens:
+
+- `{file}` full path, `{base}` basename, `{dir}` parent dir
+- `{base:}` basename without all extensions
+- `{base.}` basename without last extension
+- `{file%}` basename of `{file}`
+- `{file/}` directory of `{file}`
+- `{file^suffix}` remove a literal trailing suffix when present
+- case controls: append `!upper`, `!lower`, or `!cap` (for example `{base:!upper}`)
+
+Negative selectors in `cut -f`:
+
+- `-1` = last column
+- `-2` = second-last column
+- `-2:` = from second-last to the final column
+
 
 Matches deduplicate by default; add `-D/--allow-dups` to keep every occurrence when multiple selectors target the same column.
 
@@ -271,6 +300,13 @@ tsvkit filter -e '$group == "case" & $purity >= 0.94' examples/samples.tsv
 
 ```bash
 tsvkit filter -e '$status !in ["fail","missing","error"] & $tech ~ "sRNA"' examples/samples.tsv
+```
+
+Case helpers are supported in filter expressions:
+
+```bash
+tsvkit filter -e 'cap($1) == "HELLO"' data.tsv
+tsvkit filter -e 'upper($group) == "CASE"' examples/samples.tsv
 ```
 
 **Expression building blocks for `filter`**
@@ -306,6 +342,18 @@ tsvkit join -f subject_id examples/samples.tsv examples/subjects.tsv
 
 Control join type with `-k` (`-k 0` = full outer). Use `-F/--select` to specify output columns (defaults to all non-key columns); syntax mirrors `-f`. `--fill TEXT` supplies placeholders for missing combinations, while `--sorted` streams pre-sorted data. `tsvkit join` trims unused columns before indexing, and `-t/--threads` (default up to 8) balances throughput and resource usage.
 
+Use `--add-header` to override emitted non-key header names with per-file/per-column templates:
+
+```bash
+tsvkit join \
+  -f 'subject_id;subject_id' \
+  -F 'group,purity;sex,age' \
+  --add-header '{base:}_group,{base:}_purity;{base:}_sex,{base:}_age' \
+  examples/samples.tsv examples/subjects.tsv
+```
+
+Formatting rules: split files with `;`, columns with `,`, and keep counts aligned with `-F` for each file. Template tokens are shared with `cut --file-col`.
+
 ### `mutate`
 Create derived columns or rewrite values using expressions.
 
@@ -336,6 +384,25 @@ Apply in-place edits with the sed-style form:
 tsvkit mutate -e 's/$group/ctrl/control/' examples/samples.tsv
 ```
 
+Multiple expressions can be packed into one `-e` clause using `;`:
+
+```bash
+tsvkit mutate -e 'v1=$7/$8;v2=$11/$12' data.tsv
+```
+
+Create new columns from regex replacement with:
+
+```bash
+tsvkit mutate -e 'new=s/$2/aa[0-9]+/bb/' data.tsv
+tsvkit mutate -e 'new2=${1/aa/bb}' data.tsv
+```
+
+String case helpers can be used directly in mutate expressions:
+
+```bash
+tsvkit mutate -e 'v1=cap($2)' -e 'v2=upper($group)' data.tsv
+```
+
 **Mutation building blocks**
 
 | Form | Meaning | Example |
@@ -343,6 +410,8 @@ tsvkit mutate -e 's/$group/ctrl/control/' examples/samples.tsv
 | `name=EXPR` | Append a new column containing the evaluated expression. | `mean_signal=mean($sig1:$sig4)` |
 | `existing=EXPR` | Overwrite an existing column with the expression result. | `purity=round($purity,2)` (via custom helper script) |
 | `s/$selectors/pattern/replacement/` | Regex substitution on one or more columns (`$` optional). | `s/$group/ctrl/control/` |
+| `new=s/$selector/pattern/replacement/` | Create a new column from one source column via regex replacement. | `new=s/$2/aa/bb/` |
+| `new=${selector/pattern/replacement}` | Braced shorthand for assignment substitution. | `new=${1/aa/bb}` |
 
 **Row-wise aggregators shared by `filter` and `mutate`**
 
@@ -445,6 +514,13 @@ Take specific rows (1-based indices or ranges, including open-ended forms like `
 tsvkit slice -r 1,4:5 examples/samples.tsv
 ```
 
+### `head`
+Pretty-print the first rows of one or multiple TSV files. Default is `-n 10`; each input block starts with `# <file>`.
+
+```bash
+tsvkit head -n 5 examples/samples.tsv examples/subjects.tsv
+```
+
 ### `pretty`
 Render aligned, boxed output for quick inspection.
 
@@ -454,6 +530,13 @@ tsvkit filter -e '$group == "case"' examples/samples.tsv | tsvkit pretty
 
 - `--round DIGITS` (or `-r`) rounds numeric cells to the requested precision. Tiny magnitudes automatically switch to scientific
   notation so columns stay legible even when values approach zero.
+
+### `transpose`
+Transpose a table (rows become columns). With headers, the header row is included in transposition; use `-H` for headerless input.
+
+```bash
+tsvkit transpose examples/samples.tsv
+```
 
 ### `excel`
 Inspect `.xlsx` workbooks, preview sheets, export ranges as TSV, or assemble new workbooks from TSV inputs. Unless `-H/--no-header` is supplied, the first row of each sheet is treated as the header row; use that flag when you need to preview or export raw rows.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::{self, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 use csv::ReaderBuilder;
@@ -270,6 +270,213 @@ pub fn inconsistent_width_error(
 
 pub fn default_headers(len: usize) -> Vec<String> {
     (1..=len).map(|i| format!("col{}", i)).collect()
+}
+
+#[derive(Debug, Clone)]
+pub struct FileTemplateContext {
+    pub path: String,
+    pub base: String,
+    pub dir: String,
+}
+
+impl FileTemplateContext {
+    pub fn from_path(path: &Path) -> Self {
+        if path == Path::new("-") {
+            return FileTemplateContext {
+                path: "-".to_string(),
+                base: "-".to_string(),
+                dir: ".".to_string(),
+            };
+        }
+        let full = path.to_string_lossy().into_owned();
+        let base = path
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| full.clone());
+        let dir = path
+            .parent()
+            .map(|p| p.to_string_lossy().into_owned())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| ".".to_string());
+        FileTemplateContext {
+            path: full,
+            base,
+            dir,
+        }
+    }
+}
+
+pub fn render_file_template(template: &str, ctx: &FileTemplateContext) -> Result<String> {
+    let mut out = String::new();
+    let chars = template.chars().collect::<Vec<_>>();
+    let mut i = 0usize;
+    while i < chars.len() {
+        if chars[i] == '{' {
+            let mut j = i + 1;
+            while j < chars.len() && chars[j] != '}' {
+                j += 1;
+            }
+            if j >= chars.len() {
+                bail!("unterminated '{{' in template '{}'", template);
+            }
+            let token = chars[i + 1..j].iter().collect::<String>();
+            out.push_str(&expand_file_token(token.trim(), ctx)?);
+            i = j + 1;
+            continue;
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    Ok(out)
+}
+
+fn expand_file_token(token: &str, ctx: &FileTemplateContext) -> Result<String> {
+    let (core, case_mode) = if let Some((left, right)) = token.split_once('!') {
+        (left.trim(), Some(right.trim().to_ascii_lowercase()))
+    } else {
+        (token, None)
+    };
+
+    let (core, suffix) = if let Some((left, right)) = core.split_once('^') {
+        (left.trim(), Some(right.to_string()))
+    } else {
+        (core, None)
+    };
+
+    let mut value = match core {
+        "file" => ctx.path.clone(),
+        "base" => ctx.base.clone(),
+        "dir" => ctx.dir.clone(),
+        _ => {
+            let source;
+            let mut actions = String::new();
+            for ch in core.chars() {
+                if ch.is_ascii_alphabetic() {
+                    actions.push(ch);
+                    continue;
+                }
+            }
+            if core.starts_with("base") {
+                source = "base";
+                actions = core["base".len()..].to_string();
+            } else if core.starts_with("dir") {
+                source = "dir";
+                actions = core["dir".len()..].to_string();
+            } else if core.starts_with("file") {
+                source = "file";
+                actions = core["file".len()..].to_string();
+            } else {
+                bail!("unsupported template token '{}'", token);
+            }
+            apply_template_actions(source, &actions, ctx)?
+        }
+    };
+
+    if let Some(sfx) = suffix {
+        if value.ends_with(&sfx) {
+            let trimmed = value.len().saturating_sub(sfx.len());
+            value.truncate(trimmed);
+        }
+    }
+
+    if let Some(mode) = case_mode {
+        value = match mode.as_str() {
+            "upper" | "u" => value.to_uppercase(),
+            "lower" | "l" => value.to_lowercase(),
+            "cap" | "capitalize" | "c" => capitalize_first(&value),
+            _ => bail!("unsupported case mode '{}'", mode),
+        };
+    }
+
+    Ok(value)
+}
+
+fn apply_template_actions(
+    source: &str,
+    actions: &str,
+    ctx: &FileTemplateContext,
+) -> Result<String> {
+    let mut value = match source {
+        "file" => ctx.path.clone(),
+        "base" => ctx.base.clone(),
+        "dir" => ctx.dir.clone(),
+        _ => bail!("unsupported template source '{}'", source),
+    };
+
+    for ch in actions.chars() {
+        match ch {
+            '%' => value = basename(&value),
+            '/' => value = basedir(&value),
+            ':' => value = strip_all_extensions(&value),
+            '.' => value = strip_last_extension(&value),
+            _ if ch.is_whitespace() => {}
+            _ => bail!("unsupported template modifier '{}' in '{}'", ch, actions),
+        }
+    }
+    Ok(value)
+}
+
+fn basename(input: &str) -> String {
+    Path::new(input)
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| input.to_string())
+}
+
+fn basedir(input: &str) -> String {
+    PathBuf::from(input)
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| ".".to_string())
+}
+
+fn strip_last_extension(input: &str) -> String {
+    let path = Path::new(input);
+    if let Some(stem) = path.file_stem() {
+        if let Some(parent) = path.parent() {
+            if parent.as_os_str().is_empty() {
+                return stem.to_string_lossy().into_owned();
+            }
+            return format!("{}/{}", parent.to_string_lossy(), stem.to_string_lossy());
+        }
+        return stem.to_string_lossy().into_owned();
+    }
+    input.to_string()
+}
+
+fn strip_all_extensions(input: &str) -> String {
+    let path = Path::new(input);
+    let name = path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| input.to_string());
+    let mut core = name.clone();
+    while let Some((left, _)) = core.rsplit_once('.') {
+        if left.is_empty() {
+            break;
+        }
+        core = left.to_string();
+    }
+    if let Some(parent) = path.parent() {
+        if parent.as_os_str().is_empty() {
+            return core;
+        }
+        return format!("{}/{}", parent.to_string_lossy(), core);
+    }
+    core
+}
+
+fn capitalize_first(input: &str) -> String {
+    let mut chars = input.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => {
+            let mut out = first.to_uppercase().to_string();
+            out.push_str(chars.as_str());
+            out
+        }
+    }
 }
 
 fn parse_selector_token(token: SelectorToken) -> Result<ColumnSelector> {
@@ -727,9 +934,12 @@ fn resolve_selector_index(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::{
-        ColumnSelector, SpecialColumn, parse_selector_list, parse_single_selector,
-        resolve_selectors, resolve_selectors_allow_duplicates,
+        ColumnSelector, FileTemplateContext, SpecialColumn, parse_selector_list,
+        parse_single_selector, render_file_template, resolve_selectors,
+        resolve_selectors_allow_duplicates,
     };
 
     #[test]
@@ -837,6 +1047,32 @@ mod tests {
         let selectors = parse_selector_list("-1,-2").unwrap();
         let indices = resolve_selectors(&headers, &selectors, false).unwrap();
         assert_eq!(indices, vec![2, 1]);
+    }
+
+    #[test]
+    fn resolves_negative_open_range() {
+        let headers = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ];
+        let selectors = parse_selector_list("-2:").unwrap();
+        let indices = resolve_selectors(&headers, &selectors, false).unwrap();
+        assert_eq!(indices, vec![2, 3]);
+    }
+
+    #[test]
+    fn renders_file_template_variants() {
+        let ctx = FileTemplateContext::from_path(Path::new("/tmp/a.b.c.tsv"));
+        assert_eq!(render_file_template("{base}", &ctx).unwrap(), "a.b.c.tsv");
+        assert_eq!(render_file_template("{base.}", &ctx).unwrap(), "a.b.c");
+        assert_eq!(render_file_template("{base:}", &ctx).unwrap(), "a");
+        assert_eq!(render_file_template("{file%:}", &ctx).unwrap(), "a");
+        assert_eq!(
+            render_file_template("{file^.tsv}", &ctx).unwrap(),
+            "/tmp/a.b.c"
+        );
     }
 
     #[test]

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -5,8 +5,9 @@ use anyhow::{Context, Result, bail};
 use clap::Args;
 
 use crate::common::{
-    ColumnSelector, InputOptions, SpecialColumn, default_headers, parse_selector_list,
-    reader_for_path, resolve_selectors, resolve_selectors_allow_duplicates, should_skip_record,
+    ColumnSelector, FileTemplateContext, InputOptions, SpecialColumn, default_headers,
+    parse_selector_list, reader_for_path, render_file_template, resolve_selectors,
+    resolve_selectors_allow_duplicates, should_skip_record,
 };
 
 #[derive(Args, Debug)]
@@ -20,7 +21,13 @@ pub struct CutArgs {
     pub files: Vec<PathBuf>,
 
     /// Fields to select, using names, 1-based indices, ranges (`colA:colD`, `2:5`), regex (`~"^sample"`), or mixes. Comma-separated list.
-    #[arg(short = 'f', long = "fields", value_name = "COLS", required = true)]
+    #[arg(
+        short = 'f',
+        long = "fields",
+        value_name = "COLS",
+        required = true,
+        allow_hyphen_values = true
+    )]
     pub fields: String,
 
     /// Rename the injected file column when using `__file__` or `__base__`
@@ -67,7 +74,7 @@ pub fn run(args: CutArgs) -> Result<()> {
 
     for path in &args.files {
         let mut reader = reader_for_path(path, args.no_header, &input_opts)?;
-        let file_info = FileInfo::from_path(path);
+        let file_info = FileInfo::from_path(path).with_template(args.file_col.as_deref());
 
         if args.no_header {
             process_no_header_file(
@@ -191,15 +198,11 @@ fn emit_record(
     let mut fields = Vec::with_capacity(columns.len());
     for column in columns {
         match column {
-            CutColumn::Index(idx) => fields.push(record.get(*idx).unwrap_or("")),
-            CutColumn::Injected(special) => fields.push(file_info.value_for(*special)),
+            CutColumn::Index(idx) => fields.push(record.get(*idx).unwrap_or("").to_string()),
+            CutColumn::Injected(special) => fields.push(file_info.rendered_value_for(*special)?),
         }
     }
-    if !fields.is_empty() {
-        writeln!(writer, "{}", fields.join("\t"))?;
-    } else {
-        writer.write_all(b"\n")?;
-    }
+    writeln!(writer, "{}", fields.join("\t"))?;
     Ok(())
 }
 
@@ -245,34 +248,31 @@ fn build_cut_columns(
 
 #[derive(Clone)]
 struct FileInfo {
-    path: String,
-    base: String,
+    context: FileTemplateContext,
+    template: Option<String>,
 }
 
 impl FileInfo {
     fn from_path(path: &Path) -> Self {
-        if path == Path::new("-") {
-            return FileInfo {
-                path: "-".to_string(),
-                base: "-".to_string(),
-            };
-        }
-        let path_str = path.to_string_lossy().into_owned();
-        let base = path
-            .file_name()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_else(|| path_str.clone());
         FileInfo {
-            path: path_str,
-            base,
+            context: FileTemplateContext::from_path(path),
+            template: None,
         }
     }
 
-    fn value_for(&self, special: SpecialColumn) -> &str {
-        match special {
-            SpecialColumn::FilePath => self.path.as_str(),
-            SpecialColumn::FileBase => self.base.as_str(),
+    fn with_template(mut self, template: Option<&str>) -> Self {
+        self.template = template.map(|s| s.to_string());
+        self
+    }
+
+    fn rendered_value_for(&self, special: SpecialColumn) -> Result<String> {
+        if let Some(template) = &self.template {
+            return render_file_template(template, &self.context);
         }
+        Ok(match special {
+            SpecialColumn::FilePath => self.context.path.clone(),
+            SpecialColumn::FileBase => self.context.base.clone(),
+        })
     }
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -69,6 +69,9 @@ pub enum FunctionName {
     Log2,
     Len,
     IsNa,
+    Upper,
+    Lower,
+    Cap,
 }
 
 impl FunctionName {
@@ -83,8 +86,11 @@ impl FunctionName {
             "log2" => Ok(FunctionName::Log2),
             "len" => Ok(FunctionName::Len),
             "is_na" => Ok(FunctionName::IsNa),
+            "upper" => Ok(FunctionName::Upper),
+            "lower" => Ok(FunctionName::Lower),
+            "cap" => Ok(FunctionName::Cap),
             other => bail!(
-                "unsupported function '{}': try abs, sqrt, exp, exp2, ln, log, log10, log2, len, is_na",
+                "unsupported function '{}': try abs, sqrt, exp, exp2, ln, log, log10, log2, len, is_na, upper, lower, cap",
                 other
             ),
         }
@@ -496,6 +502,29 @@ where
                         || text.eq_ignore_ascii_case("na")
                         || text.eq_ignore_ascii_case("nan");
                     bool_eval(is_na)
+                }
+                FunctionName::Upper => EvalValue {
+                    text: Cow::Owned(inner_eval.text.to_uppercase()),
+                    numeric: None,
+                },
+                FunctionName::Lower => EvalValue {
+                    text: Cow::Owned(inner_eval.text.to_lowercase()),
+                    numeric: None,
+                },
+                FunctionName::Cap => {
+                    let mut chars = inner_eval.text.chars();
+                    let text = match chars.next() {
+                        None => String::new(),
+                        Some(first) => {
+                            let mut out = first.to_uppercase().to_string();
+                            out.push_str(chars.as_str());
+                            out
+                        }
+                    };
+                    EvalValue {
+                        text: Cow::Owned(text),
+                        numeric: None,
+                    }
                 }
             }
         }
@@ -1218,6 +1247,39 @@ mod tests {
         let row = vec!["hello".to_string()];
         let result = eval_value(&bound, &row);
         assert_eq!(result.numeric, Some(5.0));
+    }
+
+    #[test]
+    fn string_case_functions_transform_text() {
+        let headers = vec!["text".to_string()];
+        let upper = bind_value_expression(
+            parse_value_expression("upper($1)").unwrap(),
+            &headers,
+            false,
+        )
+        .unwrap();
+        let lower = bind_value_expression(
+            parse_value_expression("lower($1)").unwrap(),
+            &headers,
+            false,
+        )
+        .unwrap();
+        let cap =
+            bind_value_expression(parse_value_expression("cap($1)").unwrap(), &headers, false)
+                .unwrap();
+        let row = vec!["hELLo".to_string()];
+        assert_eq!(eval_value(&upper, &row).text.as_ref(), "HELLO");
+        assert_eq!(eval_value(&lower, &row).text.as_ref(), "hello");
+        assert_eq!(eval_value(&cap, &row).text.as_ref(), "HELLo");
+    }
+
+    #[test]
+    fn cap_function_works_in_filter_comparisons() {
+        let expr = parse_expression("cap($1) == \"HELLO\"").unwrap();
+        let headers = vec!["greet".to_string()];
+        let bound = bind_expression(expr, &headers, false).unwrap();
+        let row = csv::StringRecord::from(vec!["hELLO"]);
+        assert!(evaluate(&bound, &row));
     }
 
     #[test]

--- a/src/head.rs
+++ b/src/head.rs
@@ -1,0 +1,97 @@
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Args;
+
+use crate::common::{InputOptions, inconsistent_width_error, should_skip_record};
+use crate::pretty::render_table;
+
+#[derive(Args, Debug)]
+#[command(about = "Preview first rows in pretty format")]
+pub struct HeadArgs {
+    #[arg(value_name = "FILES", num_args = 1..)]
+    pub files: Vec<PathBuf>,
+
+    #[arg(short = 'n', long = "lines", default_value_t = 10)]
+    pub lines: usize,
+
+    #[arg(short = 'H', long = "no-header")]
+    pub no_header: bool,
+
+    #[arg(short = 'C', long = "comment-char", default_value = "#")]
+    pub comment_char: String,
+
+    #[arg(short = 'E', long = "ignore-empty-row")]
+    pub ignore_empty_row: bool,
+
+    #[arg(short = 'I', long = "ignore-illegal-row")]
+    pub ignore_illegal_row: bool,
+}
+
+pub fn run(args: HeadArgs) -> Result<()> {
+    let input_opts = InputOptions::from_flags(
+        &args.comment_char,
+        args.ignore_empty_row,
+        args.ignore_illegal_row,
+    )?;
+
+    for (idx, file) in args.files.iter().enumerate() {
+        if idx > 0 {
+            println!();
+        }
+        println!("# {}", file.display());
+
+        let mut reader = crate::common::reader_for_path(file, args.no_header, &input_opts)?;
+        let source_name = format!("\"{}\"", file.display());
+        let header = if args.no_header {
+            None
+        } else {
+            Some(
+                reader
+                    .headers()
+                    .with_context(|| format!("failed reading header from {}", source_name))?
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>(),
+            )
+        };
+        let mut rows = Vec::new();
+        let mut reference_width = header.as_ref().map(|h| h.len());
+        let header_rows = if header.is_some() { 1 } else { 0 };
+        let mut row_number = 0usize;
+
+        for record in reader.records() {
+            if rows.len() >= args.lines {
+                break;
+            }
+            let record = record.with_context(|| format!("failed reading from {}", source_name))?;
+            row_number += 1;
+            if let Some(width) = reference_width {
+                if record.len() != width {
+                    if input_opts.ignore_illegal {
+                        continue;
+                    }
+                    return Err(inconsistent_width_error(
+                        &source_name,
+                        row_number + header_rows,
+                        width,
+                        record.len(),
+                    ));
+                }
+            }
+            if should_skip_record(&record, &input_opts, reference_width) {
+                continue;
+            }
+            if reference_width.is_none() {
+                reference_width = Some(record.len());
+            }
+            rows.push(record.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+        }
+
+        render_table(header, rows)?;
+        io::stdout().flush()?;
+    }
+
+    Ok(())
+}

--- a/src/join.rs
+++ b/src/join.rs
@@ -8,9 +8,9 @@ use num_cpus;
 use rayon::{ThreadPoolBuilder, prelude::*};
 
 use crate::common::{
-    ColumnSelector, InputOptions, default_headers, inconsistent_width_error,
-    parse_multi_selector_spec, parse_selector_list, reader_for_path, resolve_selectors,
-    should_skip_record,
+    ColumnSelector, FileTemplateContext, InputOptions, default_headers, inconsistent_width_error,
+    parse_multi_selector_spec, parse_selector_list, reader_for_path, render_file_template,
+    resolve_selectors, should_skip_record,
 };
 
 #[derive(Args, Debug)]
@@ -67,6 +67,10 @@ pub struct JoinArgs {
     /// Fill value to use when a joined file lacks data for a given key (defaults to empty string)
     #[arg(long = "fill", value_name = "TEXT")]
     pub fill: Option<String>,
+
+    /// Override emitted non-key headers. Use comma per included column and ';' per file. Templates support {file}, {base}, {dir}, {base:}, {base.}, {file%}, {file/}, {file^suffix}.
+    #[arg(long = "add-header", value_name = "SPEC")]
+    pub add_header: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -315,6 +319,7 @@ fn execute_join(args: &JoinArgs, input_opts: &InputOptions, fill_value: &str) ->
             !args.no_header,
             input_opts,
             fill_value,
+            args.add_header.as_deref(),
         );
     }
 
@@ -344,7 +349,13 @@ fn execute_join(args: &JoinArgs, input_opts: &InputOptions, fill_value: &str) ->
         })
         .collect::<Result<Vec<_>>>()?;
 
-    output_joined(tables, &keep, !args.no_header)
+    output_joined(
+        tables,
+        &keep,
+        !args.no_header,
+        &args.files,
+        args.add_header.as_deref(),
+    )
 }
 
 fn load_table(
@@ -695,40 +706,17 @@ fn parse_keep_option(spec: Option<&str>, file_count: usize) -> Result<KeepStrate
     }
 }
 
-fn output_joined(tables: Vec<Table>, keep: &KeepStrategy, has_header: bool) -> Result<()> {
+fn output_joined(
+    tables: Vec<Table>,
+    keep: &KeepStrategy,
+    has_header: bool,
+    files: &[PathBuf],
+    add_header_spec: Option<&str>,
+) -> Result<()> {
     let mut writer = BufWriter::new(io::stdout().lock());
 
     if has_header {
-        let mut seen: HashMap<String, usize> = HashMap::new();
-        let mut header_fields = Vec::new();
-
-        if let Some(first_table) = tables.first() {
-            for &idx in &first_table.join_indices {
-                let original = first_table.headers.get(idx).cloned().unwrap_or_default();
-                let entry = seen.entry(original.clone()).or_insert(0);
-                if *entry == 0 {
-                    *entry = 1;
-                    header_fields.push(original);
-                } else {
-                    *entry += 1;
-                    header_fields.push(format!("{}#{}", original, *entry));
-                }
-            }
-        }
-
-        for (table_idx, table) in tables.iter().enumerate() {
-            for &col_idx in &table.include_indices {
-                let original = table.headers.get(col_idx).cloned().unwrap_or_default();
-                let entry = seen.entry(original.clone()).or_insert(0);
-                if *entry == 0 {
-                    *entry = 1;
-                    header_fields.push(original);
-                } else {
-                    *entry += 1;
-                    header_fields.push(format!("{}#{}", original, table_idx + 1));
-                }
-            }
-        }
+        let header_fields = build_join_headers(tables.as_slice(), files, add_header_spec)?;
         if !header_fields.is_empty() {
             writeln!(writer, "{}", header_fields.join("	"))?;
         }
@@ -827,6 +815,7 @@ fn stream_join(
     has_header: bool,
     input_opts: &InputOptions,
     fill_value: &str,
+    add_header_spec: Option<&str>,
 ) -> Result<()> {
     let mut tables = Vec::with_capacity(files.len());
     for (idx, path) in files.iter().enumerate() {
@@ -854,7 +843,7 @@ fn stream_join(
     let mut writer = BufWriter::new(io::stdout().lock());
 
     if has_header {
-        write_stream_header(&tables, &mut writer)?;
+        write_stream_header(&tables, files, add_header_spec, &mut writer)?;
     }
 
     loop {
@@ -931,8 +920,22 @@ fn gather_row_sets<'a>(
 
 fn write_stream_header(
     tables: &[StreamTable],
+    files: &[PathBuf],
+    add_header_spec: Option<&str>,
     writer: &mut BufWriter<io::StdoutLock<'_>>,
 ) -> Result<()> {
+    let header_fields = build_join_headers_for_stream(tables, files, add_header_spec)?;
+    if !header_fields.is_empty() {
+        writeln!(writer, "{}", header_fields.join("\t"))?;
+    }
+    Ok(())
+}
+
+fn build_join_headers_for_stream(
+    tables: &[StreamTable],
+    files: &[PathBuf],
+    add_header_spec: Option<&str>,
+) -> Result<Vec<String>> {
     let mut seen: HashMap<String, usize> = HashMap::new();
     let mut header_fields = Vec::new();
 
@@ -951,8 +954,18 @@ fn write_stream_header(
     }
 
     for (table_idx, table) in tables.iter().enumerate() {
-        for &col_idx in &table.include_indices {
-            let original = table.headers.get(col_idx).cloned().unwrap_or_default();
+        let custom_headers = resolve_add_headers_for_file(
+            add_header_spec,
+            files,
+            table_idx,
+            table.include_indices.len(),
+        )?;
+        for (pos, &col_idx) in table.include_indices.iter().enumerate() {
+            let original = custom_headers
+                .as_ref()
+                .and_then(|vals| vals.get(pos))
+                .cloned()
+                .unwrap_or_else(|| table.headers.get(col_idx).cloned().unwrap_or_default());
             let entry = seen.entry(original.clone()).or_insert(0);
             if *entry == 0 {
                 *entry = 1;
@@ -964,11 +977,118 @@ fn write_stream_header(
         }
     }
 
-    if !header_fields.is_empty() {
-        writeln!(writer, "{}", header_fields.join("\t"))?;
+    Ok(header_fields)
+}
+
+fn build_join_headers(
+    tables: &[Table],
+    files: &[PathBuf],
+    add_header_spec: Option<&str>,
+) -> Result<Vec<String>> {
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    let mut header_fields = Vec::new();
+
+    if let Some(first_table) = tables.first() {
+        for &idx in &first_table.join_indices {
+            let original = first_table.headers.get(idx).cloned().unwrap_or_default();
+            let entry = seen.entry(original.clone()).or_insert(0);
+            if *entry == 0 {
+                *entry = 1;
+                header_fields.push(original);
+            } else {
+                *entry += 1;
+                header_fields.push(format!("{}#{}", original, *entry));
+            }
+        }
     }
 
-    Ok(())
+    for (table_idx, table) in tables.iter().enumerate() {
+        let custom_headers = resolve_add_headers_for_file(
+            add_header_spec,
+            files,
+            table_idx,
+            table.include_indices.len(),
+        )?;
+        for (pos, &col_idx) in table.include_indices.iter().enumerate() {
+            let original = custom_headers
+                .as_ref()
+                .and_then(|vals| vals.get(pos))
+                .cloned()
+                .unwrap_or_else(|| table.headers.get(col_idx).cloned().unwrap_or_default());
+            let entry = seen.entry(original.clone()).or_insert(0);
+            if *entry == 0 {
+                *entry = 1;
+                header_fields.push(original);
+            } else {
+                *entry += 1;
+                header_fields.push(format!("{}#{}", original, table_idx + 1));
+            }
+        }
+    }
+
+    Ok(header_fields)
+}
+
+fn resolve_add_headers_for_file(
+    add_header_spec: Option<&str>,
+    files: &[PathBuf],
+    file_idx: usize,
+    include_count: usize,
+) -> Result<Option<Vec<String>>> {
+    let Some(raw) = add_header_spec.map(|s| s.trim()).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let groups = parse_add_header_groups(raw, files.len())?;
+    let group = groups
+        .get(file_idx)
+        .with_context(|| format!("missing --add-header group for file {}", file_idx + 1))?;
+    if group.len() != include_count {
+        bail!(
+            "--add-header group {} defines {} headers, but file {} includes {} non-key columns",
+            file_idx + 1,
+            group.len(),
+            file_idx + 1,
+            include_count
+        );
+    }
+    let context = FileTemplateContext::from_path(
+        files
+            .get(file_idx)
+            .with_context(|| format!("missing path for file {}", file_idx + 1))?,
+    );
+    let rendered = group
+        .iter()
+        .map(|item| render_file_template(item, &context))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Some(rendered))
+}
+
+fn parse_add_header_groups(raw: &str, file_count: usize) -> Result<Vec<Vec<String>>> {
+    let parts: Vec<Vec<String>> = raw
+        .split(';')
+        .map(|group| {
+            group
+                .split(',')
+                .map(|item| item.trim().to_string())
+                .filter(|item| !item.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .filter(|group| !group.is_empty())
+        .collect();
+    if parts.is_empty() {
+        bail!("--add-header specification must not be empty");
+    }
+    if parts.len() == 1 && file_count > 1 {
+        return Ok(vec![parts[0].clone(); file_count]);
+    }
+    if parts.len() != file_count {
+        bail!(
+            "--add-header expects {} file groups, got {}",
+            file_count,
+            parts.len()
+        );
+    }
+    Ok(parts)
 }
 
 fn write_stream_combinations(

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod cut;
 mod excel;
 mod expression;
 mod filter;
+mod head;
 mod info;
 mod join;
 mod melt;
@@ -19,6 +20,7 @@ mod pretty;
 mod slice;
 mod sort;
 mod summarize;
+mod transpose;
 
 #[derive(Parser)]
 #[command(
@@ -53,6 +55,10 @@ enum Commands {
     Sort(sort::SortArgs),
     /// Add derived columns or rewrite existing ones
     Mutate(mutate::MutateArgs),
+    /// Preview first rows in pretty format
+    Head(head::HeadArgs),
+    /// Transpose rows and columns
+    Transpose(transpose::TransposeArgs),
     /// Slice rows by 1-based index
     Slice(slice::SliceArgs),
     /// Excel-focused helpers (inspect, preview, convert, load)
@@ -76,6 +82,8 @@ fn main() -> Result<()> {
         Commands::Melt(args) => melt::run(args),
         Commands::Sort(args) => sort::run(args),
         Commands::Mutate(args) => mutate::run(args),
+        Commands::Head(args) => head::run(args),
+        Commands::Transpose(args) => transpose::run(args),
         Commands::Slice(args) => slice::run(args),
         Commands::Excel(args) => excel::run(args, &raw_args),
         Commands::Csv(args) => csv::run(args),

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -194,7 +194,7 @@ fn parse_operations(
 ) -> Result<Vec<MutateOp>> {
     let mut ops = Vec::new();
     let mut current_headers = headers.to_vec();
-    for expr in exprs {
+    for expr in flatten_expr_clauses(exprs)? {
         let trimmed = expr.trim();
         if trimmed.is_empty() {
             bail!("mutation expression must not be empty");
@@ -310,6 +310,25 @@ fn find_assignment(expr: &str) -> Option<usize> {
 fn parse_function(value: &str, headers: &[String], no_header: bool) -> Result<FunctionSpec> {
     let trimmed = value.trim();
 
+    if trimmed.starts_with("s/") {
+        let sub = parse_substitution_spec(trimmed, headers, no_header)?;
+        return Ok(FunctionSpec::SubNew {
+            column: sub.column,
+            pattern: sub.pattern,
+            replacement: sub.replacement,
+        });
+    }
+
+    if trimmed.starts_with("${") && trimmed.ends_with('}') {
+        let inner = &trimmed[2..trimmed.len() - 1];
+        let sub = parse_braced_substitution_spec(inner, headers, no_header)?;
+        return Ok(FunctionSpec::SubNew {
+            column: sub.column,
+            pattern: sub.pattern,
+            replacement: sub.replacement,
+        });
+    }
+
     if let Some(rest) = trimmed.strip_prefix("sub(") {
         let inner = rest
             .strip_suffix(')')
@@ -385,6 +404,61 @@ fn parse_substitution_expression(
     let regex = Regex::new(&regex_pattern).with_context(|| "invalid regex in substitution")?;
     Ok(MutateOp::Substitute {
         columns: indices,
+        pattern: regex,
+        replacement: unescape_substitution_component(replacement_part),
+    })
+}
+
+struct SubstitutionSpec {
+    column: usize,
+    pattern: Regex,
+    replacement: String,
+}
+
+fn parse_substitution_spec(
+    expr: &str,
+    headers: &[String],
+    no_header: bool,
+) -> Result<SubstitutionSpec> {
+    let content = expr.trim_start_matches("s/");
+    let content = content
+        .strip_suffix('/')
+        .with_context(|| "substitution expression must end with '/'")?;
+    let (selector_part, pattern_part, replacement_part) = split_substitution_components(content)
+        .with_context(
+            || "substitution expression must use s/selectors/pattern/replacement/ syntax",
+        )?;
+    let selectors = parse_selector_list(&normalize_selector_spec(selector_part.trim()))?;
+    if selectors.len() != 1 {
+        bail!("assignment substitution requires exactly one target column");
+    }
+    let indices = resolve_selectors(headers, &selectors, no_header)?;
+    let regex_pattern = unescape_substitution_component(pattern_part);
+    let regex = Regex::new(&regex_pattern).with_context(|| "invalid regex in substitution")?;
+    Ok(SubstitutionSpec {
+        column: indices[0],
+        pattern: regex,
+        replacement: unescape_substitution_component(replacement_part),
+    })
+}
+
+fn parse_braced_substitution_spec(
+    expr: &str,
+    headers: &[String],
+    no_header: bool,
+) -> Result<SubstitutionSpec> {
+    let (selector_part, pattern_part, replacement_part) = split_substitution_components(expr)
+        .with_context(|| "braced substitution must use ${selector/pattern/replacement} syntax")?;
+    let selector_text = selector_part.trim().trim_start_matches('$');
+    let selectors = parse_selector_list(selector_text)?;
+    if selectors.len() != 1 {
+        bail!("braced substitution requires exactly one target column");
+    }
+    let indices = resolve_selectors(headers, &selectors, no_header)?;
+    let regex = Regex::new(&unescape_substitution_component(pattern_part))
+        .with_context(|| "invalid regex in braced substitution")?;
+    Ok(SubstitutionSpec {
+        column: indices[0],
         pattern: regex,
         replacement: unescape_substitution_component(replacement_part),
     })
@@ -471,6 +545,44 @@ fn split_args(input: &str) -> Vec<String> {
         args.push(current.trim().to_string());
     }
     args
+}
+
+fn flatten_expr_clauses(exprs: &[String]) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    for expr in exprs {
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+        let mut current = String::new();
+        for ch in expr.chars() {
+            match ch {
+                '\\' if !escaped => {
+                    escaped = true;
+                    current.push(ch);
+                    continue;
+                }
+                '\'' if !escaped && !in_double => in_single = !in_single,
+                '"' if !escaped && !in_single => in_double = !in_double,
+                ';' if !in_single && !in_double => {
+                    if !current.trim().is_empty() {
+                        out.push(current.trim().to_string());
+                    }
+                    current.clear();
+                    continue;
+                }
+                _ => {}
+            }
+            escaped = false;
+            current.push(ch);
+        }
+        if in_single || in_double {
+            bail!("unterminated quote in -e expression '{}'", expr);
+        }
+        if !current.trim().is_empty() {
+            out.push(current.trim().to_string());
+        }
+    }
+    Ok(out)
 }
 
 fn parse_string_literal(value: &str) -> Result<String> {
@@ -678,5 +790,33 @@ mod tests {
     fn parse_string_literal_handles_common_escapes() {
         let literal = parse_string_literal("\"line\\nfeed\\tend\"").unwrap();
         assert_eq!(literal, "line\nfeed\tend");
+    }
+
+    #[test]
+    fn supports_multiple_assignments_in_single_e_clause() {
+        let headers = vec!["x".to_string(), "y".to_string()];
+        let ops = parse_operations(&["v1=$x;v2=$y".to_string()], &headers, false).unwrap();
+        let mut row = vec!["6".to_string(), "3".to_string()];
+        process_row(&mut row, &ops).unwrap();
+        assert_eq!(row[2], "6");
+        assert_eq!(row[3], "3");
+    }
+
+    #[test]
+    fn assignment_substitution_supports_s_syntax_and_braced_syntax() {
+        let headers = vec!["c1".to_string()];
+        let ops = parse_operations(
+            &[
+                "new=s/$c1/aa[0-9]+/bb/".to_string(),
+                "new2=${1/aa/bb}".to_string(),
+            ],
+            &headers,
+            false,
+        )
+        .unwrap();
+        let mut row = vec!["aa12".to_string()];
+        process_row(&mut row, &ops).unwrap();
+        assert_eq!(row[1], "bb");
+        assert_eq!(row[2], "bb12");
     }
 }

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -1,0 +1,86 @@
+use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Args;
+
+use crate::common::{InputOptions, inconsistent_width_error, reader_for_path, should_skip_record};
+
+#[derive(Args, Debug)]
+#[command(about = "Transpose rows and columns")]
+pub struct TransposeArgs {
+    #[arg(value_name = "FILE", default_value = "-")]
+    pub file: PathBuf,
+
+    #[arg(short = 'H', long = "no-header")]
+    pub no_header: bool,
+
+    #[arg(short = 'C', long = "comment-char", default_value = "#")]
+    pub comment_char: String,
+
+    #[arg(short = 'E', long = "ignore-empty-row")]
+    pub ignore_empty_row: bool,
+
+    #[arg(short = 'I', long = "ignore-illegal-row")]
+    pub ignore_illegal_row: bool,
+}
+
+pub fn run(args: TransposeArgs) -> Result<()> {
+    let input_opts = InputOptions::from_flags(
+        &args.comment_char,
+        args.ignore_empty_row,
+        args.ignore_illegal_row,
+    )?;
+    let mut reader = reader_for_path(&args.file, args.no_header, &input_opts)?;
+    let source_name = format!("\"{}\"", args.file.display());
+
+    let mut matrix = Vec::<Vec<String>>::new();
+    if !args.no_header {
+        let header = reader
+            .headers()
+            .with_context(|| format!("failed reading header from {}", source_name))?
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        matrix.push(header);
+    }
+
+    let mut expected_width = matrix.first().map(|r| r.len());
+    let mut row_number = 0usize;
+    for record in reader.records() {
+        let record = record.with_context(|| format!("failed reading from {}", source_name))?;
+        row_number += 1;
+        if should_skip_record(&record, &input_opts, expected_width) {
+            continue;
+        }
+        if let Some(width) = expected_width {
+            if record.len() != width {
+                if input_opts.ignore_illegal {
+                    continue;
+                }
+                return Err(inconsistent_width_error(
+                    &source_name,
+                    row_number,
+                    width,
+                    record.len(),
+                ));
+            }
+        } else {
+            expected_width = Some(record.len());
+        }
+        matrix.push(record.iter().map(|s| s.to_string()).collect());
+    }
+
+    let cols = matrix.iter().map(|r| r.len()).max().unwrap_or(0);
+    let rows = matrix.len();
+    let mut writer = BufWriter::new(io::stdout().lock());
+    for c in 0..cols {
+        let mut out = Vec::with_capacity(rows);
+        for r in 0..rows {
+            out.push(matrix[r].get(c).cloned().unwrap_or_default());
+        }
+        writeln!(writer, "{}", out.join("\t"))?;
+    }
+    writer.flush()?;
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Provide quick pretty previews (`head`) and an easy table transpose feature (`transpose`) as first-class subcommands.
- Let users customize emitted file-derived headers/values with path-based templates and allow header templates in `join` output.
- Add simple string-case helpers to the expression language and make `mutate -e` support multiple `;`-separated assignments and richer substitution shorthand (`s/.../` and `${.../.../...}`).

### Description
- Introduces two new subcommands by adding `src/head.rs` and `src/transpose.rs` and registering `Head` and `Transpose` in `main.rs`.
- Adds file-template support: `FileTemplateContext`, `render_file_template`, and token expansion/formatters in `src/common.rs`, and wires templating into `cut` (accept `--file-col` templates) and `join` (new `--add-header` option) via changes to `src/cut.rs` and `src/join.rs`.
- Extends the expression engine with string helpers `upper`, `lower`, and `cap` and corresponding parser entries in `src/expression.rs`.
- Enhances `mutate` parsing in `src/mutate.rs` to accept multiple expressions in a single `-e` clause (split on unquoted `;`) and to support assignment-style substitutions via `s/selectors/pattern/replacement/` and braced `${selector/pattern/replacement}` forms.
- Updates documentation (`README.md`) with usage for `head`, `transpose`, file-template tokens, case helpers, and mutate substitution examples, and bumps package version to `0.9.7` in `Cargo.toml`/`Cargo.lock`.

### Testing
- Ran the test suite with `cargo test`, which executed and passed the added and existing unit tests including template rendering and selector tests (`renders_file_template_variants`, `resolves_negative_open_range`), expression tests (`string_case_functions_transform_text`, `cap_function_works_in_filter_comparisons`), and mutate tests (`supports_multiple_assignments_in_single_e_clause`, `assignment_substitution_supports_s_syntax_and_braced_syntax`).
- Built the project with `cargo build --release` to ensure the new subcommands and API changes compile cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6711e6248832abfe712fac68effe6)