### PR TITLE
Add --key-header to join, switch `head` to stream TSV, bump version to 0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "tsvkit"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsvkit"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -355,15 +355,18 @@ tsvkit join \
 
 Formatting rules: split files with `;`, columns with `,`, and keep counts aligned with `-F` for each file. Template tokens are shared with `cut --file-col`.
 
-When using `-H` (no input header) together with `--add-header`, `join` now emits a header row:
-- join-key columns are named `index1`, `index2`, ..., `indexN`
+When using `-H` (no input header) together with `--add-header`, `join` emits a header row:
+- join-key columns are named `index1`, `index2`, ..., `indexN` by default
 - non-key columns use your `--add-header` templates.
+
+Use `--key-header` (alias `--index-name`) to rename join-key columns explicitly. Provide comma-separated names and match the number of join columns.
 
 Example:
 
 ```bash
 tsvkit join -H \
   -f '1;1' \
+  --key-header 'sample_id' \
   --add-header 'patient_{base:#sample_}' \
   sample_A.tsv sample_B.tsv
 ```
@@ -529,10 +532,11 @@ tsvkit slice -r 1,4:5 examples/samples.tsv
 ```
 
 ### `head`
-Pretty-print the first rows of one or multiple TSV files. Default is `-n 10`; each input block starts with `# <file>`.
+Print the first rows from TSV input (default `-n 10`). With one input (including stdin), output is plain TSV with no file banner; with multiple files, each block is prefixed by `# <file>`.
 
 ```bash
 tsvkit head -n 5 examples/samples.tsv examples/subjects.tsv
+cat examples/samples.tsv | tsvkit head -n 3
 ```
 
 ### `pretty`

--- a/src/head.rs
+++ b/src/head.rs
@@ -1,16 +1,15 @@
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::Args;
 
 use crate::common::{InputOptions, inconsistent_width_error, should_skip_record};
-use crate::pretty::render_table;
 
 #[derive(Args, Debug)]
-#[command(about = "Preview first rows in pretty format")]
+#[command(about = "Print first rows from TSV input")]
 pub struct HeadArgs {
-    #[arg(value_name = "FILES", num_args = 1..)]
+    #[arg(value_name = "FILES", default_value = "-", num_args = 0..)]
     pub files: Vec<PathBuf>,
 
     #[arg(short = 'n', long = "lines", default_value_t = 10)]
@@ -36,33 +35,37 @@ pub fn run(args: HeadArgs) -> Result<()> {
         args.ignore_illegal_row,
     )?;
 
+    let mut writer = BufWriter::new(io::stdout().lock());
+    let show_file_banner = args.files.len() > 1;
+
     for (idx, file) in args.files.iter().enumerate() {
         if idx > 0 {
-            println!();
+            writeln!(writer)?;
         }
-        println!("# {}", file.display());
+        if show_file_banner {
+            writeln!(writer, "# {}", file.display())?;
+        }
 
         let mut reader = crate::common::reader_for_path(file, args.no_header, &input_opts)?;
         let source_name = format!("\"{}\"", file.display());
-        let header = if args.no_header {
-            None
-        } else {
-            Some(
-                reader
-                    .headers()
-                    .with_context(|| format!("failed reading header from {}", source_name))?
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<_>>(),
-            )
-        };
-        let mut rows = Vec::new();
-        let mut reference_width = header.as_ref().map(|h| h.len());
-        let header_rows = if header.is_some() { 1 } else { 0 };
+        let mut reference_width = None;
+        let mut header_rows = 0usize;
+        if !args.no_header {
+            let header = reader
+                .headers()
+                .with_context(|| format!("failed reading header from {}", source_name))?
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>();
+            reference_width = Some(header.len());
+            header_rows = 1;
+            writeln!(writer, "{}", header.join("\t"))?;
+        }
         let mut row_number = 0usize;
+        let mut emitted_rows = 0usize;
 
         for record in reader.records() {
-            if rows.len() >= args.lines {
+            if emitted_rows >= args.lines {
                 break;
             }
             let record = record.with_context(|| format!("failed reading from {}", source_name))?;
@@ -86,12 +89,15 @@ pub fn run(args: HeadArgs) -> Result<()> {
             if reference_width.is_none() {
                 reference_width = Some(record.len());
             }
-            rows.push(record.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+            writeln!(
+                writer,
+                "{}",
+                record.iter().collect::<Vec<_>>().join("\t")
+            )?;
+            emitted_rows += 1;
         }
-
-        render_table(header, rows)?;
-        io::stdout().flush()?;
     }
 
+    writer.flush()?;
     Ok(())
 }

--- a/src/join.rs
+++ b/src/join.rs
@@ -71,6 +71,10 @@ pub struct JoinArgs {
     /// Override emitted non-key headers. Use comma per included column and ';' per file. Templates support {file}, {base}, {dir}, {base:}, {base.}, {file%}, {file/}, {file^suffix}.
     #[arg(long = "add-header", value_name = "SPEC")]
     pub add_header: Option<String>,
+
+    /// Override emitted join-key header names (comma-separated). Must match number of join columns. Alias: --index-name.
+    #[arg(long = "key-header", alias = "index-name", value_name = "NAMES")]
+    pub key_header: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -316,10 +320,11 @@ fn execute_join(args: &JoinArgs, input_opts: &InputOptions, fill_value: &str) ->
             &select_specs,
             &keep,
             args.no_header,
-            !args.no_header || args.add_header.is_some(),
+            !args.no_header || args.add_header.is_some() || args.key_header.is_some(),
             input_opts,
             fill_value,
             args.add_header.as_deref(),
+            args.key_header.as_deref(),
         );
     }
 
@@ -352,10 +357,11 @@ fn execute_join(args: &JoinArgs, input_opts: &InputOptions, fill_value: &str) ->
     output_joined(
         tables,
         &keep,
-        !args.no_header || args.add_header.is_some(),
+        !args.no_header || args.add_header.is_some() || args.key_header.is_some(),
         args.no_header,
         &args.files,
         args.add_header.as_deref(),
+        args.key_header.as_deref(),
     )
 }
 
@@ -714,12 +720,18 @@ fn output_joined(
     no_header: bool,
     files: &[PathBuf],
     add_header_spec: Option<&str>,
+    key_header_spec: Option<&str>,
 ) -> Result<()> {
     let mut writer = BufWriter::new(io::stdout().lock());
 
     if emit_header {
-        let header_fields =
-            build_join_headers(tables.as_slice(), files, add_header_spec, no_header)?;
+        let header_fields = build_join_headers(
+            tables.as_slice(),
+            files,
+            add_header_spec,
+            key_header_spec,
+            no_header,
+        )?;
         if !header_fields.is_empty() {
             writeln!(writer, "{}", header_fields.join("	"))?;
         }
@@ -819,6 +831,7 @@ fn stream_join(
     input_opts: &InputOptions,
     fill_value: &str,
     add_header_spec: Option<&str>,
+    key_header_spec: Option<&str>,
 ) -> Result<()> {
     let mut tables = Vec::with_capacity(files.len());
     for (idx, path) in files.iter().enumerate() {
@@ -846,7 +859,14 @@ fn stream_join(
     let mut writer = BufWriter::new(io::stdout().lock());
 
     if emit_header {
-        write_stream_header(&tables, files, add_header_spec, no_header, &mut writer)?;
+        write_stream_header(
+            &tables,
+            files,
+            add_header_spec,
+            key_header_spec,
+            no_header,
+            &mut writer,
+        )?;
     }
 
     loop {
@@ -925,10 +945,12 @@ fn write_stream_header(
     tables: &[StreamTable],
     files: &[PathBuf],
     add_header_spec: Option<&str>,
+    key_header_spec: Option<&str>,
     no_header: bool,
     writer: &mut BufWriter<io::StdoutLock<'_>>,
 ) -> Result<()> {
-    let header_fields = build_join_headers_for_stream(tables, files, add_header_spec, no_header)?;
+    let header_fields =
+        build_join_headers_for_stream(tables, files, add_header_spec, key_header_spec, no_header)?;
     if !header_fields.is_empty() {
         writeln!(writer, "{}", header_fields.join("\t"))?;
     }
@@ -939,18 +961,27 @@ fn build_join_headers_for_stream(
     tables: &[StreamTable],
     files: &[PathBuf],
     add_header_spec: Option<&str>,
+    key_header_spec: Option<&str>,
     no_header: bool,
 ) -> Result<Vec<String>> {
     let mut seen: HashMap<String, usize> = HashMap::new();
     let mut header_fields = Vec::new();
 
     if let Some(first_table) = tables.first() {
+        let key_headers =
+            resolve_key_headers_spec(key_header_spec, first_table.join_indices.len())?;
         for (pos, &idx) in first_table.join_indices.iter().enumerate() {
-            let original = if no_header {
-                format!("index{}", pos + 1)
-            } else {
-                first_table.headers.get(idx).cloned().unwrap_or_default()
-            };
+            let original = key_headers
+                .as_ref()
+                .and_then(|vals| vals.get(pos))
+                .cloned()
+                .unwrap_or_else(|| {
+                    if no_header {
+                        format!("index{}", pos + 1)
+                    } else {
+                        first_table.headers.get(idx).cloned().unwrap_or_default()
+                    }
+                });
             let entry = seen.entry(original.clone()).or_insert(0);
             if *entry == 0 {
                 *entry = 1;
@@ -993,18 +1024,27 @@ fn build_join_headers(
     tables: &[Table],
     files: &[PathBuf],
     add_header_spec: Option<&str>,
+    key_header_spec: Option<&str>,
     no_header: bool,
 ) -> Result<Vec<String>> {
     let mut seen: HashMap<String, usize> = HashMap::new();
     let mut header_fields = Vec::new();
 
     if let Some(first_table) = tables.first() {
+        let key_headers =
+            resolve_key_headers_spec(key_header_spec, first_table.join_indices.len())?;
         for (pos, &idx) in first_table.join_indices.iter().enumerate() {
-            let original = if no_header {
-                format!("index{}", pos + 1)
-            } else {
-                first_table.headers.get(idx).cloned().unwrap_or_default()
-            };
+            let original = key_headers
+                .as_ref()
+                .and_then(|vals| vals.get(pos))
+                .cloned()
+                .unwrap_or_else(|| {
+                    if no_header {
+                        format!("index{}", pos + 1)
+                    } else {
+                        first_table.headers.get(idx).cloned().unwrap_or_default()
+                    }
+                });
             let entry = seen.entry(original.clone()).or_insert(0);
             if *entry == 0 {
                 *entry = 1;
@@ -1041,6 +1081,28 @@ fn build_join_headers(
     }
 
     Ok(header_fields)
+}
+
+fn resolve_key_headers_spec(spec: Option<&str>, join_width: usize) -> Result<Option<Vec<String>>> {
+    let Some(raw) = spec.map(|s| s.trim()).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let headers: Vec<String> = raw
+        .split(',')
+        .map(|item| item.trim().to_string())
+        .filter(|item| !item.is_empty())
+        .collect();
+    if headers.is_empty() {
+        bail!("--key-header specification must not be empty");
+    }
+    if headers.len() != join_width {
+        bail!(
+            "--key-header defines {} names, but join uses {} key columns",
+            headers.len(),
+            join_width
+        );
+    }
+    Ok(Some(headers))
 }
 
 fn resolve_add_headers_for_file(
@@ -1215,11 +1277,41 @@ mod tests {
             &[table1, table2],
             &files,
             Some("patient_{base:#sample_};patient_{base:#sample_}"),
+            None,
             true,
         )
         .unwrap();
         assert_eq!(headers[0], "index1");
         assert_eq!(headers[1], "patient_A");
         assert_eq!(headers[2], "patient_B");
+    }
+
+    #[test]
+    fn key_header_overrides_join_key_names() {
+        let table1 = Table {
+            headers: vec!["col1".to_string(), "col2".to_string()],
+            join_indices: vec![0, 1],
+            include_indices: vec![],
+            rows: Vec::new(),
+            key_to_rows: HashMap::new(),
+            key_order: Vec::new(),
+            empty_row: vec![],
+        };
+        let table2 = Table {
+            headers: vec!["col1".to_string(), "col2".to_string()],
+            join_indices: vec![0, 1],
+            include_indices: vec![],
+            rows: Vec::new(),
+            key_to_rows: HashMap::new(),
+            key_order: Vec::new(),
+            empty_row: vec![],
+        };
+        let files = vec![
+            PathBuf::from("/tmp/sample_A.tsv"),
+            PathBuf::from("/tmp/sample_B.tsv"),
+        ];
+        let headers =
+            build_join_headers(&[table1, table2], &files, None, Some("id,sample"), true).unwrap();
+        assert_eq!(headers, vec!["id".to_string(), "sample".to_string()]);
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a way to explicitly name join-key columns when using `tsvkit join` so users can override default `indexN` names or header-derived names.
- Make `tsvkit head` behave like typical Unix tools and stream plain TSV for single-file/stdin input instead of rendering a pretty boxed table.
- Update documentation and release metadata to reflect the behavioral changes and a new patch version.

### Description

- Add a new CLI option `--key-header` (alias `--index-name`) to `JoinArgs` and thread `key_header` through `execute_join`, `stream_join`, `output_joined`, and header-writing helpers. 
- Implement `resolve_key_headers_spec` to validate and parse the `--key-header` specification and prefer those names when building join headers for both streaming and in-memory joins. 
- Update `head` implementation to read from stdin by default, use a `BufWriter`, emit file banners only when multiple inputs are provided, print the header row when present, and stream rows as TSV lines instead of rendering with `render_table`, removing the pretty-formatting path. 
- Update `README.md` to document the new `--key-header` behavior, clarify `join` and `head` semantics, and adjust examples; bump package version in `Cargo.toml` and update `Cargo.lock` to `0.9.8`. 
- Add unit tests covering the join header behavior with `--key-header`.

### Testing

- Ran `cargo test` and the unit test suite (including the new header override test) passed.
- Built the project with `cargo build` to verify compilation after API changes and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69df3d358832a8c591a542d533689)