### PR TITLE
Support template-based injected file columns and customizable injected column names in `cut`

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,22 +259,26 @@ Explanation:
 -	`__base__` injects the source filename as the first column
 -	`1:` selects all existing columns from each input file
 
-You can use `--file-col` or `--fc` to define a custom column name for the injected column. For example, 
+You can now inject file-derived values directly in `-f` with template selectors:
 
 ```bash
-tsvkit cut --fc sample -f '__base__,1:' examples/qc*.tsv
+tsvkit cut -f '{file},{base:},1:2' examples/qc.tsv
+tsvkit cut -f 'sample={base:#sample_!lower},1:' sample_A.tsv
 ```
-The column name will be "sample" not "__base__" in the output.
 
-`--file-col` now also accepts file-template expressions so injected values can be derived from paths:
+Use `--inject-col-names` (aliases: `--file-col`, `--fc`) to rename injected columns.
+If you have multiple injected selectors in `-f`, pass comma-separated names in order:
 
 ```bash
-tsvkit cut --file-col '{base:}' -f '__file__,1:2' examples/qc.tsv
+tsvkit cut --inject-col-names sample -f '__base__,1:' examples/qc*.tsv
+tsvkit cut --inject-col-names file_name,sample -f '{base:},sample={base:#sample_!upper},1:2' sample_A.tsv
 ```
 
 Template tokens:
 
-- `{file}` full path, `{base}` basename, `{dir}` parent dir
+- `{file}` / `{__file__}` full path
+- `{base}` / `{__base__}` basename
+- `{dir}` / `{__dir__}` parent dir
 - `{base:}` basename without all extensions
 - `{base.}` basename without last extension
 - `{file%}` basename of `{file}`
@@ -282,6 +286,8 @@ Template tokens:
 - `{file^suffix}` remove a literal trailing suffix when present
 - `{base:#prefix}` remove a literal prefix when present (example: `{base:#sample_}`)
 - case controls: append `!upper`, `!lower`, or `!cap` (for example `{base:!upper}`)
+
+> Shell tip: `!` is interpreted by many shells in double quotes. Use **single quotes** for selector/template expressions like `'{base:!lower},1:3'` or `'sample={base:!lower},1:'`. If you must use double quotes, escape it: `"{base:\!lower}"`.
 
 Negative selectors in `cut -f`:
 
@@ -291,6 +297,13 @@ Negative selectors in `cut -f`:
 
 
 Matches deduplicate by default; add `-D/--allow-dups` to keep every occurrence when multiple selectors target the same column.
+
+Useful operational flags:
+
+- `-H/--no-header` for headerless TSVs (selectors are index-based)
+- `-C/--comment-char` to skip comment lines (default `#`)
+- `-E/--ignore-empty-row` to skip blank rows
+- `-I/--ignore-illegal-row` to skip rows with inconsistent column counts
 
 ### `filter`
 Filter rows with boolean logic, arithmetic, column ranges, regexes, and list membership tests.
@@ -353,7 +366,7 @@ tsvkit join \
   examples/samples.tsv examples/subjects.tsv
 ```
 
-Formatting rules: split files with `;`, columns with `,`, and keep counts aligned with `-F` for each file. Template tokens are shared with `cut --file-col`.
+Formatting rules: split files with `;`, columns with `,`, and keep counts aligned with `-F` for each file. Template tokens are shared with `cut -f '{...}'` template selectors.
 
 When using `-H` (no input header) together with `--add-header`, `join` emits a header row:
 - join-key columns are named `index1`, `index2`, ..., `indexN` by default

--- a/src/common.rs
+++ b/src/common.rs
@@ -30,18 +30,27 @@ pub enum ColumnSelector {
     FromEnd(usize),
     Name(String),
     Regex(String),
+    Template(String),
     Range(Option<Box<ColumnSelector>>, Option<Box<ColumnSelector>>),
     Special(SpecialColumn),
 }
 
 pub fn parse_selector_list(spec: &str) -> Result<Vec<ColumnSelector>> {
+    parse_selector_list_impl(spec, false)
+}
+
+pub fn parse_selector_list_with_templates(spec: &str) -> Result<Vec<ColumnSelector>> {
+    parse_selector_list_impl(spec, true)
+}
+
+fn parse_selector_list_impl(spec: &str, braces_as_templates: bool) -> Result<Vec<ColumnSelector>> {
     if spec.trim().is_empty() {
         bail!("column specification must not be empty");
     }
 
     tokenize_selector_spec(spec)?
         .into_iter()
-        .map(parse_selector_token)
+        .map(|token| parse_selector_token(token, braces_as_templates))
         .collect()
 }
 
@@ -135,6 +144,12 @@ fn resolve_selectors_with_options(
                 let mut resolved =
                     resolve_selector_indices(headers, selector, no_header, allow_duplicates)?;
                 indices.append(&mut resolved);
+            }
+            ColumnSelector::Template(template) => {
+                bail!(
+                    "template selector '{{{}}}' cannot be resolved as a positional index",
+                    template
+                );
             }
             ColumnSelector::Range(start, end) => {
                 if headers.is_empty() {
@@ -350,9 +365,9 @@ fn expand_file_token(token: &str, ctx: &FileTemplateContext) -> Result<String> {
     };
 
     let mut value = match core {
-        "file" => ctx.path.clone(),
-        "base" => ctx.base.clone(),
-        "dir" => ctx.dir.clone(),
+        "file" | "__file__" => ctx.path.clone(),
+        "base" | "__base__" => ctx.base.clone(),
+        "dir" | "__dir__" => ctx.dir.clone(),
         _ => {
             let source;
             let mut actions = String::new();
@@ -362,7 +377,16 @@ fn expand_file_token(token: &str, ctx: &FileTemplateContext) -> Result<String> {
                     continue;
                 }
             }
-            if core.starts_with("base") {
+            if core.starts_with("__base__") {
+                source = "base";
+                actions = core["__base__".len()..].to_string();
+            } else if core.starts_with("__dir__") {
+                source = "dir";
+                actions = core["__dir__".len()..].to_string();
+            } else if core.starts_with("__file__") {
+                source = "file";
+                actions = core["__file__".len()..].to_string();
+            } else if core.starts_with("base") {
                 source = "base";
                 actions = core["base".len()..].to_string();
             } else if core.starts_with("dir") {
@@ -491,7 +515,7 @@ fn capitalize_first(input: &str) -> String {
     }
 }
 
-fn parse_selector_token(token: SelectorToken) -> Result<ColumnSelector> {
+fn parse_selector_token(token: SelectorToken, braces_as_templates: bool) -> Result<ColumnSelector> {
     if token.text.is_empty() {
         return Err(anyhow!("empty column selector"));
     }
@@ -508,20 +532,26 @@ fn parse_selector_token(token: SelectorToken) -> Result<ColumnSelector> {
         let start_selector = if start_trim.is_empty() {
             None
         } else {
-            Some(Box::new(parse_simple_selector(start_trim)?))
+            Some(Box::new(parse_simple_selector(
+                start_trim,
+                braces_as_templates,
+            )?))
         };
         let end_selector = if end_trim.is_empty() {
             None
         } else {
-            Some(Box::new(parse_simple_selector(end_trim)?))
+            Some(Box::new(parse_simple_selector(
+                end_trim,
+                braces_as_templates,
+            )?))
         };
         return Ok(ColumnSelector::Range(start_selector, end_selector));
     }
 
-    parse_simple_selector(&token.text)
+    parse_simple_selector(&token.text, braces_as_templates)
 }
 
-fn parse_simple_selector(token: &str) -> Result<ColumnSelector> {
+fn parse_simple_selector(token: &str, braces_as_templates: bool) -> Result<ColumnSelector> {
     if token.is_empty() {
         return Err(anyhow!("empty column selector"));
     }
@@ -532,6 +562,9 @@ fn parse_simple_selector(token: &str) -> Result<ColumnSelector> {
         return Ok(ColumnSelector::Name(literal));
     }
     if let Some(literal) = parse_brace_literal(token)? {
+        if braces_as_templates {
+            return Ok(ColumnSelector::Template(literal));
+        }
         return Ok(ColumnSelector::Name(literal));
     }
     match token {
@@ -882,6 +915,10 @@ fn resolve_selector_indices(
             }
             Ok(matches)
         }
+        ColumnSelector::Template(template) => bail!(
+            "template selector '{{{}}}' cannot be resolved as a positional index",
+            template
+        ),
         ColumnSelector::Range(_, _) => unreachable!("range selectors handled separately"),
         ColumnSelector::Special(special) => bail!(
             "special column '{}' not supported without column injection",
@@ -934,6 +971,12 @@ fn resolve_selector_index(
         ColumnSelector::Regex(_) => {
             bail!("regex column selectors cannot be used in range endpoints")
         }
+        ColumnSelector::Template(template) => {
+            bail!(
+                "template selector '{{{}}}' cannot be used in range endpoints",
+                template
+            )
+        }
         ColumnSelector::Special(special) => bail!(
             "special column '{}' not supported without column injection",
             special.default_header()
@@ -950,8 +993,8 @@ mod tests {
 
     use super::{
         ColumnSelector, FileTemplateContext, SpecialColumn, parse_selector_list,
-        parse_single_selector, render_file_template, resolve_selectors,
-        resolve_selectors_allow_duplicates,
+        parse_selector_list_with_templates, parse_single_selector, render_file_template,
+        resolve_selectors, resolve_selectors_allow_duplicates,
     };
 
     #[test]
@@ -1054,6 +1097,13 @@ mod tests {
     }
 
     #[test]
+    fn parses_brace_templates_when_enabled() {
+        let selectors = parse_selector_list_with_templates("{base:},plain").unwrap();
+        assert!(matches!(selectors[0], ColumnSelector::Template(ref name) if name == "base:"));
+        assert!(matches!(selectors[1], ColumnSelector::Name(ref name) if name == "plain"));
+    }
+
+    #[test]
     fn parses_negative_indices() {
         let headers = vec!["a".to_string(), "b".to_string(), "c".to_string()];
         let selectors = parse_selector_list("-1,-2").unwrap();
@@ -1087,6 +1137,8 @@ mod tests {
             render_file_template("{file^.tsv}", &ctx).unwrap(),
             "/tmp/a.b.c"
         );
+        assert_eq!(render_file_template("{__file__%:}", &ctx).unwrap(), "a");
+        assert_eq!(render_file_template("{__base__.}", &ctx).unwrap(), "a.b.c");
     }
 
     #[test]

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -6,21 +6,57 @@ use clap::Args;
 
 use crate::common::{
     ColumnSelector, FileTemplateContext, InputOptions, SpecialColumn, default_headers,
-    parse_selector_list, reader_for_path, render_file_template, resolve_selectors,
+    parse_selector_list_with_templates, reader_for_path, render_file_template, resolve_selectors,
     resolve_selectors_allow_duplicates, should_skip_record,
 };
 
 #[derive(Args, Debug)]
 #[command(
     about = "Select and reorder TSV columns",
-    long_about = "Pick columns by name or 1-based index. Combine comma-separated selectors with ranges (colA:colD or 2:6) and single fields in one spec. Use ~\"regex\" to match columns by pattern. Defaults to header-aware mode; add -H for headerless input.\n\nExamples:\n  tsvkit cut -f id,sample3,sample1 examples/profiles.tsv\n  tsvkit cut -f 'Purity,sample:FN,F1' examples/profiles.tsv\n  tsvkit cut -H -f 3,1 data.tsv"
+    after_help = "Selector syntax:
+  name,index,range,regex mix:  id,2,group:tech,~\"^IL\"
+  negative indices/ranges:     -1,-2:     (last column, second-last to end)
+  literal symbol names:        `2:4`      (avoid selector parsing)
+
+Injected selectors:
+  __file__   inject file path per row
+  __base__   inject file basename per row
+  {file}     inject rendered template value (also {base}, {dir}, modifiers)
+  sample={base:!lower}   inline header+template alias
+
+Injected header names:
+  --inject-col-names sample,file_base
+  (aliases: --file-col, --fc)
+
+Template tokens:
+  {file} {base} {dir}
+  aliases: __file__ == file, __base__ == base, __dir__ == dir
+  modifiers: : (strip all ext), . (strip last ext), % (basename), / (dirname)
+  trims: ^suffix (remove trailing suffix), #prefix (remove leading prefix)
+  case: !lower !upper !cap
+
+Shell quoting note:
+  Use single quotes when templates contain '!': '{base:!lower}'
+  In double quotes, escape '!': \"{base:\\!lower}\"
+
+Examples:
+  tsvkit cut -f 'sample_id,group,purity' examples/samples.tsv
+  tsvkit cut -f '1,group,~\"^IL\",-1' examples/cytokines.tsv
+  tsvkit cut -f '{file},{base:},1:2' examples/qc.tsv
+  tsvkit cut -f 'sample={base:#sample_!lower},1:' sample_A.tsv
+  tsvkit cut -f '__base__,1:' examples/qc*.tsv
+  tsvkit cut --inject-col-names sample -f '__base__,1:' examples/qc*.tsv
+  tsvkit cut --inject-col-names file_name,sample -f '{base:},sample={base:#sample_!upper},1:2' sample_A.tsv
+  tsvkit cut -H -f '3,1,-1' data.tsv
+  tsvkit cut -C ';' -E -I -f '1:3' dirty.tsv
+  tsvkit cut -D -f 'value,~\"^value$\"' duplicated_headers.tsv"
 )]
 pub struct CutArgs {
     /// Input TSV file(s) (use '-' for stdin; supports gz/xz)
     #[arg(value_name = "FILES", num_args = 0.., default_values = ["-"])]
     pub files: Vec<PathBuf>,
 
-    /// Fields to select, using names, 1-based indices, ranges (`colA:colD`, `2:5`), regex (`~"^sample"`), or mixes. Comma-separated list.
+    /// Fields to select, using names, 1-based indices, ranges (`colA:colD`, `2:5`), regex (`~"^sample"`), templates (`{base:}`), or mixes. Comma-separated list.
     #[arg(
         short = 'f',
         long = "fields",
@@ -30,9 +66,13 @@ pub struct CutArgs {
     )]
     pub fields: String,
 
-    /// Rename the injected file column when using `__file__` or `__base__`
-    #[arg(long = "file-col", visible_alias = "fc", value_name = "NAME")]
-    pub file_col: Option<String>,
+    /// Comma-separated header names for injected columns (template/special selectors in -f)
+    #[arg(
+        long = "inject-col-names",
+        visible_aliases = ["file-col", "fc"],
+        value_name = "NAMES"
+    )]
+    pub inject_col_names: Option<String>,
 
     /// Treat the input as headerless (columns referenced by 1-based indices)
     #[arg(short = 'H', long = "no-header")]
@@ -61,7 +101,7 @@ pub struct CutArgs {
 }
 
 pub fn run(args: CutArgs) -> Result<()> {
-    let selectors = parse_selector_list(&args.fields)?;
+    let selectors = parse_selector_list_with_templates(&args.fields)?;
     let input_opts = InputOptions::from_flags(
         &args.comment_char,
         args.ignore_empty_row,
@@ -69,12 +109,12 @@ pub fn run(args: CutArgs) -> Result<()> {
     )?;
     let mut writer = BufWriter::new(io::stdout().lock());
 
-    let file_column_config = FileColumnConfig::new(args.file_col.as_deref());
+    let file_column_config = FileColumnConfig::parse(args.inject_col_names.as_deref())?;
     let mut header_emitted = false;
 
     for path in &args.files {
         let mut reader = reader_for_path(path, args.no_header, &input_opts)?;
-        let file_info = FileInfo::from_path(path).with_template(args.file_col.as_deref());
+        let file_info = FileInfo::from_path(path);
 
         if args.no_header {
             process_no_header_file(
@@ -162,6 +202,8 @@ fn process_header_file(
     let expected_width = headers.len();
 
     if !*header_emitted {
+        file_column_config.validate_count(&columns)?;
+        let mut injected_idx = 0usize;
         let header_fields: Vec<String> = columns
             .iter()
             .map(|column| match column {
@@ -170,7 +212,20 @@ fn process_header_file(
                     .map(|s| s.as_str())
                     .unwrap_or("")
                     .to_string(),
-                CutColumn::Injected(special) => file_column_config.header_for(*special),
+                CutColumn::Injected(special) => {
+                    let name = file_column_config
+                        .header_for(injected_idx)
+                        .unwrap_or_else(|| special.default_header().to_string());
+                    injected_idx += 1;
+                    name
+                }
+                CutColumn::Template { header, .. } => {
+                    let name = file_column_config
+                        .header_for(injected_idx)
+                        .unwrap_or_else(|| header.clone());
+                    injected_idx += 1;
+                    name
+                }
             })
             .collect();
         if !header_fields.is_empty() {
@@ -200,6 +255,9 @@ fn emit_record(
         match column {
             CutColumn::Index(idx) => fields.push(record.get(*idx).unwrap_or("").to_string()),
             CutColumn::Injected(special) => fields.push(file_info.rendered_value_for(*special)?),
+            CutColumn::Template { template, .. } => {
+                fields.push(render_file_template(template, &file_info.context)?)
+            }
         }
     }
     writeln!(writer, "{}", fields.join("\t"))?;
@@ -216,15 +274,26 @@ fn build_cut_columns(
     for selector in selectors {
         match selector {
             ColumnSelector::Special(special) => columns.push(CutColumn::Injected(*special)),
+            ColumnSelector::Template(template) => {
+                let raw = format!("{{{}}}", template);
+                columns.push(CutColumn::Template {
+                    header: raw.clone(),
+                    template: raw,
+                });
+            }
             ColumnSelector::Range(start, end) => {
-                if start
-                    .as_deref()
-                    .map_or(false, |sel| matches!(sel, ColumnSelector::Special(_)))
-                    || end
-                        .as_deref()
-                        .map_or(false, |sel| matches!(sel, ColumnSelector::Special(_)))
-                {
-                    bail!("special columns cannot be used within a range selector");
+                if start.as_deref().map_or(false, |sel| {
+                    matches!(
+                        sel,
+                        ColumnSelector::Special(_) | ColumnSelector::Template(_)
+                    )
+                }) || end.as_deref().map_or(false, |sel| {
+                    matches!(
+                        sel,
+                        ColumnSelector::Special(_) | ColumnSelector::Template(_)
+                    )
+                }) {
+                    bail!("special/template columns cannot be used within a range selector");
                 }
                 let indices = if allow_duplicates {
                     resolve_selectors_allow_duplicates(headers, &[selector.clone()], no_header)?
@@ -234,6 +303,12 @@ fn build_cut_columns(
                 columns.extend(indices.into_iter().map(CutColumn::Index));
             }
             _ => {
+                if let ColumnSelector::Name(name) = selector {
+                    if let Some((header, template)) = parse_inline_template_selector(name) {
+                        columns.push(CutColumn::Template { header, template });
+                        continue;
+                    }
+                }
                 let indices = if allow_duplicates {
                     resolve_selectors_allow_duplicates(headers, &[selector.clone()], no_header)?
                 } else {
@@ -249,26 +324,16 @@ fn build_cut_columns(
 #[derive(Clone)]
 struct FileInfo {
     context: FileTemplateContext,
-    template: Option<String>,
 }
 
 impl FileInfo {
     fn from_path(path: &Path) -> Self {
         FileInfo {
             context: FileTemplateContext::from_path(path),
-            template: None,
         }
-    }
-
-    fn with_template(mut self, template: Option<&str>) -> Self {
-        self.template = template.map(|s| s.to_string());
-        self
     }
 
     fn rendered_value_for(&self, special: SpecialColumn) -> Result<String> {
-        if let Some(template) = &self.template {
-            return render_file_template(template, &self.context);
-        }
         Ok(match special {
             SpecialColumn::FilePath => self.context.path.clone(),
             SpecialColumn::FileBase => self.context.base.clone(),
@@ -277,23 +342,90 @@ impl FileInfo {
 }
 
 struct FileColumnConfig<'a> {
-    rename: Option<&'a str>,
+    names: Vec<&'a str>,
 }
 
 impl<'a> FileColumnConfig<'a> {
-    fn new(rename: Option<&'a str>) -> Self {
-        FileColumnConfig { rename }
+    fn parse(spec: Option<&'a str>) -> Result<Self> {
+        let names = spec
+            .map(|s| {
+                s.split(',')
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        Ok(FileColumnConfig { names })
     }
 
-    fn header_for(&self, special: SpecialColumn) -> String {
-        match self.rename {
-            Some(name) => name.to_string(),
-            None => special.default_header().to_string(),
+    fn header_for(&self, injected_idx: usize) -> Option<String> {
+        self.names.get(injected_idx).map(|s| s.to_string())
+    }
+
+    fn validate_count(&self, columns: &[CutColumn]) -> Result<()> {
+        let injected_count = columns.iter().filter(|c| c.is_injected()).count();
+        if self.names.len() > injected_count {
+            bail!(
+                "--inject-col-names provided {} name(s), but only {} injected column(s) are selected",
+                self.names.len(),
+                injected_count
+            );
         }
+        Ok(())
     }
 }
 
 enum CutColumn {
     Index(usize),
     Injected(SpecialColumn),
+    Template { header: String, template: String },
+}
+
+impl CutColumn {
+    fn is_injected(&self) -> bool {
+        matches!(self, CutColumn::Injected(_) | CutColumn::Template { .. })
+    }
+}
+
+fn parse_inline_template_selector(token: &str) -> Option<(String, String)> {
+    let (header, template) = token.split_once('=')?;
+    let header = header.trim();
+    let template = template.trim();
+    if header.is_empty()
+        || template.len() < 2
+        || !template.starts_with('{')
+        || !template.ends_with('}')
+    {
+        return None;
+    }
+    Some((header.to_string(), template.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::common::SpecialColumn;
+
+    use super::{CutColumn, FileColumnConfig, parse_inline_template_selector};
+
+    #[test]
+    fn parses_inline_template_selector() {
+        let parsed = parse_inline_template_selector("sample={base:!lower}").unwrap();
+        assert_eq!(parsed.0, "sample");
+        assert_eq!(parsed.1, "{base:!lower}");
+    }
+
+    #[test]
+    fn parses_injected_column_names() {
+        let cfg = FileColumnConfig::parse(Some("a, b ,c")).unwrap();
+        assert_eq!(cfg.header_for(0).as_deref(), Some("a"));
+        assert_eq!(cfg.header_for(1).as_deref(), Some("b"));
+        assert_eq!(cfg.header_for(2).as_deref(), Some("c"));
+    }
+
+    #[test]
+    fn rejects_too_many_injected_names() {
+        let cfg = FileColumnConfig::parse(Some("a,b")).unwrap();
+        let columns = vec![CutColumn::Injected(SpecialColumn::FileBase)];
+        assert!(cfg.validate_count(&columns).is_err());
+    }
 }


### PR DESCRIPTION
### Motivation
- Allow injecting file-derived values using template selectors (e.g. `{base:!lower}`) directly in `-f` rather than only special `__file__/__base__` tokens or a single `--file-col` rename. 
- Provide a way to supply explicit header names for any injected/template selectors and validate count mismatches.
- Improve template token aliasing and rendering so both `__file__`/`__base__` and `{file}`/`{base}` forms work consistently.

### Description
- Added a `Template(String)` selector variant and new parsing path `parse_selector_list_with_templates` so brace tokens can be interpreted as templates when enabled. 
- Extended template rendering to accept `__file__`, `__base__`, and `__dir__` aliases and to detect/parse `__...__` prefixed tokens correctly in `expand_file_token` and `render_file_template`.
- Updated `cut` to accept template selectors in `-f`, support inline header aliases like `sample={base:!lower}`, and inject template values into output rows via a new `CutColumn::Template` variant.
- Replaced single `--file-col` option with `--inject-col-names` (aliases: `--file-col`, `--fc`) which accepts comma-separated header names for injected/template columns and validates the provided names count against the number of injected columns selected.
- Improved CLI help/README text to document template tokens, quoting guidance, new flags (`--inject-col-names`), operational flags, and examples.
- Added unit tests for template parsing/rendering, inline template selectors, injected name parsing, and validation logic; adjusted existing tests to account for template aliasing.

### Testing
- Ran the unit test suite with `cargo test`, which executed new and updated tests in `src/common.rs` and `src/cut.rs`, and all tests passed.
- Built the project (`cargo build`) to ensure the CLI compiles successfully, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c6980eb4832abaf32801dafe13b5)