### PR TITLE
Enhance CLI help text, examples, and usage notes across subcommands

### DIFF
--- a/src/csv/mod.rs
+++ b/src/csv/mod.rs
@@ -9,7 +9,22 @@ use crate::common::{InputOptions, open_path_reader, should_skip_record};
 #[derive(Args, Debug)]
 #[command(
     about = "Tools for working with comma-separated values",
-    long_about = "Convert comma-separated data to TSV while preserving headers and allowing custom delimiters."
+    long_about = "Convert delimited text (CSV by default) to clean TSV output. Supports stdin/files, custom delimiters, comment skipping, NA replacement for blanks, and forgiving parsing for messy quoted inputs.",
+    after_help = "Examples:
+  tsvkit csv data.csv > data.tsv
+  tsvkit csv --delim ';' data_semicolon.csv > data.tsv
+  tsvkit csv --na NA clinical.csv > clinical.tsv
+  tsvkit csv --lazy-quotes broken_quotes.csv > repaired.tsv
+  zcat data.csv.gz | tsvkit csv - > data.tsv
+
+When to use:
+  - Ingest CSV before running tsvkit cut/filter/summarize.
+  - Normalize messy vendor exports into a stable TSV pipeline.
+
+Option notes:
+  --delim expects exactly one character.
+  -H/--no-header treats the first row as data.
+  --lazy-quotes is useful when embedded quotes are not escaped correctly."
 )]
 pub struct CsvArgs {
     /// Input CSV file (use '-' for stdin; gz/xz supported)

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -49,7 +49,12 @@ Examples:
   tsvkit cut --inject-col-names file_name,sample -f '{base:},sample={base:#sample_!upper},1:2' sample_A.tsv
   tsvkit cut -H -f '3,1,-1' data.tsv
   tsvkit cut -C ';' -E -I -f '1:3' dirty.tsv
-  tsvkit cut -D -f 'value,~\"^value$\"' duplicated_headers.tsv"
+  tsvkit cut -D -f 'value,~\"^value$\"' duplicated_headers.tsv
+
+Practical tips:
+  - Use -f first, then pipe into filter/summarize/sort for analysis workflows.
+  - Use regex selectors (~\"...\") to keep evolving column groups (e.g. assays).
+  - Use template/injected selectors to preserve provenance when concatenating files."
 )]
 pub struct CutArgs {
     /// Input TSV file(s) (use '-' for stdin; supports gz/xz)

--- a/src/excel/mod.rs
+++ b/src/excel/mod.rs
@@ -19,7 +19,34 @@ type CellValue = Data;
 #[derive(Args, Debug)]
 #[command(
     about = "Interact with Excel workbooks",
-    long_about = "Inspect, preview, export, or build Excel workbooks (xlsx).",
+    long_about = "Inspect, preview, export, or build Excel workbooks (.xlsx).\n\n`tsvkit excel` has 4 mutually exclusive modes:\n  --sheets FILE    list sheet metadata (name, size, inferred types)\n  --preview FILE   show first rows from selected sheets\n  --dump FILE      export selected sheet as TSV\n  --load TSV ...   create a workbook from TSV input(s)",
+    after_help = "Common workflows:
+  1) Inspect workbook structure
+     tsvkit excel --sheets examples/bioinfo_example.xlsx
+
+  2) Preview one sheet with pretty rendering
+     tsvkit excel --preview book.xlsx -s Sheet1 -n 15 --pretty
+
+  3) Dump a subset of rows/columns as TSV
+     tsvkit excel --dump book.xlsx -s 2 -f 'A:D,score' -r '1:200'
+
+  4) Build a new workbook from multiple TSV files
+     tsvkit excel --load cohort.tsv --load qc.tsv -o report.xlsx
+
+Key option explanations:
+  -s/--sheet NAME|INDEX   repeat to select sheets; default is all/first depending on mode
+  -f/--fields SPEC        for dump mode, select columns by name/index/Excel letters
+  -r/--rows SPEC          for dump mode, select row ranges (supports from-end selectors)
+  --values/--formulas     choose evaluated values (default) or raw formulas
+  --dates MODE            date rendering/writing mode: raw, excel, iso
+  --na STR                blank replacement during dump; NA marker during load
+  --types MODE            load mode type handling: infer or string
+  --max-rows-per-sheet N  split large loads across multiple sheets safely
+
+Tips:
+  - Use --no-header when the first row is data, not column names.
+  - Pair `--dump` with other tsvkit commands for robust TSV pipelines."
+,
     group = ArgGroup::new("mode")
         .args(["sheets", "preview", "dump", "load"])
         .required(true),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -15,7 +15,22 @@ use crate::expression::{bind_expression, evaluate, parse_expression};
 Examples:
   tsvkit filter -e '$sample2>=5 & $sample3!=9' examples/profiles.tsv
   tsvkit filter -e '$kingdom ~ "^Bact"' examples/abundance.tsv
-  tsvkit filter -e 'log2($coverage) > 10' reads.tsv"#
+  tsvkit filter -e 'log2($coverage) > 10' reads.tsv"#,
+    after_help = "More expression patterns:
+  Numeric range:
+    tsvkit filter -e '$score >= 0.8 & $score <= 0.95' data.tsv
+  Membership:
+    tsvkit filter -e '$group in [\"case\",\"control\"]' data.tsv
+  Negation:
+    tsvkit filter -e '!($status == \"failed\")' data.tsv
+  Row-wise aggregate filter:
+    tsvkit filter -e 'mean($sample1:$sample5) > 10' data.tsv
+
+Tips:
+  - Always quote expressions so your shell does not expand `$col`.
+  - Prefer double quotes for string literals inside expressions.
+  - In -H mode, use `$1`, `$2`, ... selectors.
+  - `filter` emits headers only when at least one row matches."
 )]
 pub struct FilterArgs {
     /// Input TSV file (use '-' for stdin; compressed files supported)

--- a/src/head.rs
+++ b/src/head.rs
@@ -7,23 +7,44 @@ use clap::Args;
 use crate::common::{InputOptions, inconsistent_width_error, should_skip_record};
 
 #[derive(Args, Debug)]
-#[command(about = "Print first rows from TSV input")]
+#[command(
+    about = "Print first rows from TSV input",
+    long_about = "Preview the top portion of one or more TSV files. In header mode (default), the header row is always emitted before data rows. When multiple files are provided, each section is prefixed by '# <file>'.\n\nUseful for quick sanity checks in pipelines before running heavier commands.",
+    after_help = "Examples:
+  tsvkit head examples/profiles.tsv
+  tsvkit head -n 25 examples/abundance.tsv
+  tsvkit head -n 5 sample_a.tsv sample_b.tsv
+  tsvkit head -H -n 20 raw_no_header.tsv
+  zcat large.tsv.gz | tsvkit head -n 10 -
+
+Notes:
+  -n/--lines counts only data rows (header is additional when present).
+  -H/--no-header disables header handling and prints raw first rows.
+  Pair with `tsvkit pretty` for easier terminal reading:
+    tsvkit head -n 15 data.tsv | tsvkit pretty"
+)]
 pub struct HeadArgs {
+    /// Input TSV file(s) (use '-' for stdin; gz/xz supported)
     #[arg(value_name = "FILES", default_value = "-", num_args = 0..)]
     pub files: Vec<PathBuf>,
 
+    /// Number of data rows to print from the top (default 10)
     #[arg(short = 'n', long = "lines", default_value_t = 10)]
     pub lines: usize,
 
+    /// Treat input as headerless (no header row is emitted)
     #[arg(short = 'H', long = "no-header")]
     pub no_header: bool,
 
+    /// Lines starting with this comment character are skipped
     #[arg(short = 'C', long = "comment-char", default_value = "#")]
     pub comment_char: String,
 
+    /// Ignore rows where every field is empty/whitespace
     #[arg(short = 'E', long = "ignore-empty-row")]
     pub ignore_empty_row: bool,
 
+    /// Ignore rows whose column count differs from the header/first row
     #[arg(short = 'I', long = "ignore-illegal-row")]
     pub ignore_illegal_row: bool,
 }
@@ -89,11 +110,7 @@ pub fn run(args: HeadArgs) -> Result<()> {
             if reference_width.is_none() {
                 reference_width = Some(record.len());
             }
-            writeln!(
-                writer,
-                "{}",
-                record.iter().collect::<Vec<_>>().join("\t")
-            )?;
+            writeln!(writer, "{}", record.iter().collect::<Vec<_>>().join("\t"))?;
             emitted_rows += 1;
         }
     }

--- a/src/info.rs
+++ b/src/info.rs
@@ -10,7 +10,25 @@ use crate::common::{InputOptions, reader_for_path, should_skip_record};
 #[derive(Args, Debug)]
 #[command(
     about = "Inspect TSV dimensions, column types, and value previews",
-    long_about = r#"Report the table shape and column details for a TSV file (or stdin). The output starts with #shape(rows, cols) followed by a TSV summary listing each column's index, optional name, inferred type (num/date/str), and the first N observed values (default 3). Respects shared options like -H/--no-header, -C/--comment-char, -E/--ignore-empty-row, and -I/--ignore-illegal-row."#
+    long_about = r#"Report table shape and per-column profile details for a TSV file (or stdin). Output starts with #shape(rows, cols), followed by a summary table containing each column's index, optional name, inferred type (num/date/str), and the first N observed values (default 3)."#,
+    after_help = "Examples:
+  tsvkit info examples/profiles.tsv
+  tsvkit info -n 5 examples/abundance.tsv
+  tsvkit info -H raw_no_header.tsv
+  zcat large.tsv.gz | tsvkit info -
+
+How to read output:
+  #shape(r, c)          -> number of data rows and final detected columns
+  type=num              -> all non-empty observed values looked numeric
+  type=date             -> all non-empty observed values matched YYYY-MM-DD
+  type=str              -> mixed/other values
+  firstN=[...]          -> first observed values in that column (for quick QA)
+
+Practical workflow:
+  Use `info` first, then feed column names into:
+    tsvkit cut -f ...
+    tsvkit filter -e ...
+    tsvkit summarize -s ..."
 )]
 pub struct InfoArgs {
     /// Input TSV file (use '-' for stdin; gz/xz supported)

--- a/src/join.rs
+++ b/src/join.rs
@@ -16,7 +16,21 @@ use crate::common::{
 #[derive(Args, Debug)]
 #[command(
     about = "Join multiple TSV files on shared key columns",
-    long_about = "Join two or more TSV files on one or more key columns. Provide selectors with -f/--fields (comma-separated list; use semicolons to give per-file specs). Each file must contribute the same number of key columns. Use -F/--select to control which non-key columns are emitted per file (wrap multi-file specs in quotes). Keys default to an inner join; adjust with -k/--keep. Control parallel input loading with -t/--threads (defaults to min(8, available CPUs)). When inputs are pre-sorted by the key, add --sorted to stream without buffering.\n\nExamples:\n  tsvkit join -f id examples/metadata.tsv examples/abundance.tsv\n  tsvkit join -f 'sample_id,taxon;id,taxon_id' file1.tsv file2.tsv\n  tsvkit join -f subject_id;subject_id -F 'sample_id,group;age,sex' examples/samples.tsv examples/subjects.tsv\n  tsvkit join -f id -k 0 examples/metadata.tsv examples/abundance.tsv"
+    long_about = "Join two or more TSV files on one or more key columns. Provide selectors with -f/--fields (comma-separated list; use semicolons to give per-file specs). Each file must contribute the same number of key columns. Use -F/--select to control which non-key columns are emitted per file (wrap multi-file specs in quotes). Keys default to an inner join; adjust with -k/--keep. Control parallel input loading with -t/--threads (defaults to min(8, available CPUs)). When inputs are pre-sorted by the key, add --sorted to stream without buffering.\n\nExamples:\n  tsvkit join -f id examples/metadata.tsv examples/abundance.tsv\n  tsvkit join -f 'sample_id,taxon;id,taxon_id' file1.tsv file2.tsv\n  tsvkit join -f subject_id;subject_id -F 'sample_id,group;age,sex' examples/samples.tsv examples/subjects.tsv\n  tsvkit join -f id -k 0 examples/metadata.tsv examples/abundance.tsv",
+    after_help = "Join mode guide:
+  default (inner): keep keys present in every file
+  -k 0           : full outer join (keep union of keys)
+  -k 1,3         : keep keys present in file1 or file3 (plus standard matches)
+
+Field spec guide:
+  -f 'id;id'                 -> join file1.id with file2.id
+  -f 'a,b;x,y'               -> 2-column key join
+  -F 'name,group;count'      -> choose emitted non-key columns per file
+  --add-header 'meta_{base},abund_{base}' -> custom output header templates
+
+Performance tips:
+  Use --sorted when all inputs are already sorted by join keys.
+  Use -t to tune parallel loading for very large datasets."
 )]
 pub struct JoinArgs {
     /// Input TSV files to join (use '-' to read from stdin; `.tsv`, `.tsv.gz`, `.tsv.xz` all supported)

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ mod transpose;
     name = "tsvkit",
     version,
     about = "High-level TSV toolkit: join, filter, reshape, summarize.",
-    long_about = "tsvkit is a Swiss-army knife for tab-separated data. It ships focused subcommands for joins, filtering, column selection, statistics, reshaping, and pretty-printing. Every subcommand reads from files or standard input and respects headers by default.",
+    long_about = "tsvkit is a Swiss-army knife for tab-separated data. It ships focused subcommands for joins, filtering, column selection, statistics, reshaping, spreadsheet interop, and pretty-printing.\n\nQuick start workflow:\n  1) Inspect columns and value types\n     tsvkit info data.tsv\n  2) Keep only columns you need\n     tsvkit cut -f 'sample_id,group,score' data.tsv\n  3) Filter rows with an expression\n     tsvkit filter -e '$score >= 80 & $group == \"case\"' data.tsv\n  4) Sort results and preview\n     tsvkit sort -k score:nr data.tsv | tsvkit head -n 20 | tsvkit pretty\n\nMost commands are header-aware by default and share these safety flags:\n  -H/--no-header        treat input as headerless\n  -C/--comment-char     skip comment-prefixed lines (default '#')\n  -E/--ignore-empty-row skip fully empty rows\n  -I/--ignore-illegal-row skip inconsistent-width rows\n\nGet detailed usage for any subcommand:\n  tsvkit <subcommand> --help\n\nExamples:\n  tsvkit join --help\n  tsvkit summarize --help\n  tsvkit excel --help",
     author = "tsvkit"
 )]
 struct Cli {
@@ -37,35 +37,35 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Join multiple TSV files on matching keys
+    /// Join multiple TSV files on matching keys (inner/left/right/full)
     Join(join::JoinArgs),
-    /// Summarize columns after grouping rows
+    /// Summarize numeric/text columns with grouped statistics
     Summarize(summarize::SummarizeArgs),
-    /// Select and reorder columns
+    /// Select, reorder, and inject columns (including file metadata)
     Cut(cut::CutArgs),
-    /// Pretty-print the table with aligned columns
+    /// Pretty-print TSV as an aligned terminal table
     Pretty(pretty::PrettyArgs),
-    /// Filter rows using expressions on column values
+    /// Filter rows using boolean expressions on column values
     Filter(filter::FilterArgs),
-    /// Pivot long data into wide format
+    /// Pivot long/tidy data into wide format
     Pivot(pivot::PivotArgs),
-    /// Melt wide data into long format
+    /// Melt wide tables into long/tidy format
     Melt(melt::MeltArgs),
-    /// Sort rows by one or more key columns
+    /// Sort rows by one or more text/numeric key columns
     Sort(sort::SortArgs),
-    /// Add derived columns or rewrite existing ones
+    /// Add derived columns or rewrite values with expressions/substitutions
     Mutate(mutate::MutateArgs),
-    /// Preview first rows in pretty format
+    /// Print the first N rows (header-aware)
     Head(head::HeadArgs),
     /// Transpose rows and columns
     Transpose(transpose::TransposeArgs),
-    /// Slice rows by 1-based index
+    /// Slice rows by 1-based index/ranges (supports from-end selectors)
     Slice(slice::SliceArgs),
-    /// Excel-focused helpers (inspect, preview, convert, load)
+    /// Excel helpers: inspect sheets, preview, dump TSV, or load TSV into xlsx
     Excel(excel::ExcelArgs),
-    /// CSV utilities (convert to TSV)
+    /// CSV utilities (convert CSV/TSV-like delimited text into TSV)
     Csv(csv::CsvArgs),
-    /// Inspect TSV schema, column types, and previews
+    /// Inspect table shape, schema hints, and sample values
     Info(info::InfoArgs),
 }
 

--- a/src/melt.rs
+++ b/src/melt.rs
@@ -13,7 +13,22 @@ use crate::common::{
 #[derive(Args, Debug)]
 #[command(
     about = "Melt wide TSV tables into long form",
-    long_about = "Convert wide TSV tables into a tidy long format. Use -i/--id to keep identifier columns, optionally -v/--value-cols to target specific value columns, and rename the generated columns with --variable/--value. Defaults to header-aware mode; add -H for headerless files.\n\nExample:\n  tsvkit melt -i id examples/profiles.tsv"
+    long_about = "Convert wide TSV tables into a tidy long format. Use -i/--id to keep identifier columns, optionally -v/--value-cols to target specific value columns, and rename the generated columns with --variable/--value. Defaults to header-aware mode; add -H for headerless files.\n\nExample:\n  tsvkit melt -i id examples/profiles.tsv",
+    after_help = "Use cases:
+  Keep subject metadata while melting assay columns:
+    tsvkit melt -i 'sample_id,group' -v 'IL6:IL10' cytokines.tsv
+  Melt all non-id columns:
+    tsvkit melt -i id profiles.tsv
+  Headerless matrix:
+    tsvkit melt -H -i 1 -v 2: raw.tsv
+
+Column naming:
+  --variable sets the output column storing former header names.
+  --value sets the output column storing cell values.
+
+Tip:
+  `melt` is commonly paired with `pivot`:
+    tsvkit melt -i id wide.tsv | tsvkit pivot -i id -c variable -v value"
 )]
 pub struct MeltArgs {
     /// Input TSV file (use '-' for stdin; gz/xz supported)

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -21,7 +21,19 @@ Examples:
   tsvkit mutate -e "coverage_sum=sum($1,$3:$5)" examples/profiles.tsv
   tsvkit mutate -e "log_counts=mean($count1:$count5)" counts.tsv
   tsvkit mutate -e "title_clean=sub($title,\"\\s+\", \"_\")" titles.tsv
-  tsvkit mutate -e 's/$col1:$col3/NA/0/' data.tsv"#
+  tsvkit mutate -e 's/$col1:$col3/NA/0/' data.tsv"#,
+    after_help = "Mutation patterns:
+  Add new columns (evaluated left-to-right):
+    tsvkit mutate -e 'total=$a+$b' -e 'ratio=$a/$total' data.tsv
+  Recode text in place:
+    tsvkit mutate -e 's/$group/^ctrl$/control/' data.tsv
+  Combine assignment + substitution:
+    tsvkit mutate -e 'score_z=($score-mean($score))/sd($score)' -e 's/$status/NA/unknown/' data.tsv
+
+Important notes:
+  - Always prefix column references with `$`.
+  - New columns created in earlier -e expressions can be used in later ones.
+  - Use single quotes around -e arguments to protect `$...` from shell expansion."
 )]
 pub struct MutateArgs {
     /// Input TSV file (use '-' for stdin; gz/xz supported)

--- a/src/pivot.rs
+++ b/src/pivot.rs
@@ -13,7 +13,19 @@ use crate::common::{
 #[derive(Args, Debug)]
 #[command(
     about = "Pivot long-form TSV data into wide tables",
-    long_about = "Convert long (tidy) TSV data into a wide table by promoting row values to columns. Specify which columns remain as identifiers (-i/--index), which column provides the new headers (-c/--column), and which supplies cell values (-v/--value). Use --fill for missing combinations.\n\nExample:\n  tsvkit melt -i id examples/profiles.tsv | tsvkit pivot -i id -c variable -v value"
+    long_about = "Convert long (tidy) TSV data into a wide table by promoting row values to columns. Specify which columns remain as identifiers (-i/--index), which column provides the new headers (-c/--column), and which supplies cell values (-v/--value). Use --fill for missing combinations.\n\nExample:\n  tsvkit melt -i id examples/profiles.tsv | tsvkit pivot -i id -c variable -v value",
+    after_help = "Pivot recipe:
+  -i/--index   row identity columns (can be multiple)
+  -c/--column  values in this column become new output headers
+  -v/--value   values in this column fill pivoted cells
+
+Examples:
+  tsvkit pivot -i sample_id -c analyte -v signal long.tsv
+  tsvkit pivot -i 'subject,visit' -c metric -v value --fill 0 long.tsv
+  tsvkit pivot -H -i 1 -c 2 -v 3 raw_long.tsv
+
+Round-trip with melt:
+  tsvkit melt -i id wide.tsv | tsvkit pivot -i id -c variable -v value"
 )]
 pub struct PivotArgs {
     /// Input TSV file (use '-' for stdin; gz/xz supported)

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -10,7 +10,16 @@ use crate::common::{InputOptions, inconsistent_width_error, reader_for_path, sho
 #[derive(Args, Debug)]
 #[command(
     about = "Render TSV data in a pretty table",
-    long_about = "Format TSV rows into an aligned, boxed table for quick inspection. Reads from files or stdin, keeps headers by default, and supports width control.\n\nExample:\n  tsvkit pretty examples/profiles.tsv"
+    long_about = "Format TSV rows into an aligned, boxed table for quick inspection in the terminal. Reads from files or stdin and supports table width limits to avoid wrapping explosions on very wide datasets.",
+    after_help = "Examples:
+  tsvkit pretty examples/profiles.tsv
+  tsvkit cut -f 'sample_id,group,purity' examples/samples.tsv | tsvkit pretty
+  tsvkit filter -e '$score > 80' scores.tsv | tsvkit head -n 20 | tsvkit pretty
+
+Tips:
+  Use -n to preview only the first rows for huge files.
+  Use -w to cap rendered width (truncates long cells visually).
+  Great for interactive exploration before exporting raw TSV downstream."
 )]
 pub struct PrettyArgs {
     /// Input TSV file (use '-' for stdin)

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -13,7 +13,20 @@ use crate::common::{InputOptions, reader_for_path, should_skip_record};
 
 Examples:
   tsvkit slice -r 1,10:20 examples/profiles.tsv
-  tsvkit slice -H -r 5:10 raw.tsv"#
+  tsvkit slice -H -r 5:10 raw.tsv"#,
+    after_help = "Row selector patterns:
+  7        -> single row
+  10:20    -> inclusive range
+  :50      -> from first row through 50
+  100:     -> from row 100 to end
+  -1       -> last row
+  -10:     -> last 10 rows
+  1,5,9:12 -> mixed selectors
+
+Tips:
+  Header mode (default): header is printed once before selected rows.
+  No-header mode (-H): emits only selected data rows.
+  From-end selectors require buffering to know total row count."
 )]
 pub struct SliceArgs {
     /// Input TSV file (use '-' for stdin; gz/xz supported)

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -14,7 +14,21 @@ use crate::common::{
 #[derive(Args, Debug)]
 #[command(
     about = "Sort TSV rows by column keys",
-    long_about = "Sort TSV rows by one or more keys. Provide -k/--key with column selectors (names or 1-based indices) and optional modifiers: :n (numeric asc), :nr (numeric desc), :r (reverse text). Repeat -k for additional sort levels. Defaults to header-aware mode; add -H for headerless files.\n\nExamples:\n  tsvkit sort -k count:nr examples/abundance.tsv\n  tsvkit sort -k $1:nr -k $2:r examples/profiles.tsv"
+    long_about = "Sort TSV rows by one or more keys. Provide -k/--key with column selectors (names or 1-based indices) and optional modifiers: :n (numeric asc), :nr (numeric desc), :r (reverse text). Repeat -k for additional sort levels. Defaults to header-aware mode; add -H for headerless files.\n\nExamples:\n  tsvkit sort -k count:nr examples/abundance.tsv\n  tsvkit sort -k $1:nr -k $2:r examples/profiles.tsv",
+    after_help = "Key spec quick reference:
+  -k col        text ascending
+  -k col:r      text descending
+  -k col:n      numeric ascending
+  -k col:nr     numeric descending
+
+Multi-key examples:
+  tsvkit sort -k group -k score:nr data.tsv
+  tsvkit sort -k date -k sample_id data.tsv
+  tsvkit sort -H -k 3:n -k 1 raw.tsv
+
+Tips:
+  Stable sort (default) preserves input order for equal keys.
+  Use --unstable for speed when equal-key order does not matter."
 )]
 pub struct SortArgs {
     /// Input TSV file (use '-' for stdin; gz/xz supported)

--- a/src/summarize.rs
+++ b/src/summarize.rs
@@ -17,7 +17,24 @@ use crate::common::{
 #[derive(Args, Debug)]
 #[command(
     about = "Grouped statistics over TSV columns",
-    long_about = "Group rows with -g/--group and compute statistics for selected columns via -s/--stat. Each --stat accepts COLUMN=ops, where COLUMN can be names, indices, ranges, or mixes, and ops include sum, mean, median, quantiles (q1, q50, q0.9), var, sd, mode, distinct, and more. Headers are used by default; add -H for headerless input.\n\nExamples:\n  tsvkit summarize -s 'sample1:sample3=mean' examples/profiles.tsv\n  tsvkit summarize -g group -s 'sample1=mean,sd' -s 'sample2:sample3=sum' examples/profiles.tsv\n  tsvkit summarize -s 'sample1=q1,q3,var' examples/profiles.tsv"
+    long_about = "Group rows with -g/--group and compute statistics for selected columns via -s/--stat. Each --stat accepts COLUMN=ops, where COLUMN can be names, indices, ranges, or mixes, and ops include sum, mean, median, quantiles (q1, q50, q0.9), var, sd, mode, distinct, and more. Headers are used by default; add -H for headerless input.\n\nExamples:\n  tsvkit summarize -s 'sample1:sample3=mean' examples/profiles.tsv\n  tsvkit summarize -g group -s 'sample1=mean,sd' -s 'sample2:sample3=sum' examples/profiles.tsv\n  tsvkit summarize -s 'sample1=q1,q3,var' examples/profiles.tsv",
+    after_help = "Stats guide:
+  Basic numeric ops: sum, mean, median, min, max, sd, var
+  Count-like ops: count, distinct(countunique), unique, collapse
+  Robust/advanced: trimmean, iqr, mode, antimode, entropy, argmin, argmax
+  Quantiles: q1, q3, q50, q0.9, p95, etc.
+
+Examples by use case:
+  One-row table summary:
+    tsvkit summarize -s 'value=sum,mean,sd' data.tsv
+  Per-group KPIs:
+    tsvkit summarize -g cohort -s 'score=mean,sd,q1,q3' data.tsv
+  Multiple targets with regex:
+    tsvkit summarize -s '~\"^IL\"=mean,max' cytokines.tsv
+
+Tips:
+  Repeat -s for readability on complex summaries.
+  Use -D when regex/name selectors intentionally match duplicate headers."
 )]
 pub struct SummarizeArgs {
     /// Input TSV file (use '-' for stdin; compressed files are detected automatically)

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -7,20 +7,37 @@ use clap::Args;
 use crate::common::{InputOptions, inconsistent_width_error, reader_for_path, should_skip_record};
 
 #[derive(Args, Debug)]
-#[command(about = "Transpose rows and columns")]
+#[command(
+    about = "Transpose rows and columns",
+    long_about = "Swap table axes so rows become columns and columns become rows. This is handy when samples are rows but downstream tooling expects samples as columns (or vice versa). By default, headers are included as the first row before transposition.",
+    after_help = "Examples:
+  tsvkit transpose examples/profiles.tsv
+  tsvkit transpose -H matrix_no_header.tsv
+  tsvkit cut -f 'sample1:sample3' examples/profiles.tsv | tsvkit transpose
+
+Behavior notes:
+  Header mode (default): header participates in transpose as row 1.
+  No-header mode (-H): all rows are treated as data only.
+  Ragged rows are rejected unless -I/--ignore-illegal-row is enabled."
+)]
 pub struct TransposeArgs {
+    /// Input TSV file (use '-' for stdin; gz/xz supported)
     #[arg(value_name = "FILE", default_value = "-")]
     pub file: PathBuf,
 
+    /// Treat input as headerless
     #[arg(short = 'H', long = "no-header")]
     pub no_header: bool,
 
+    /// Lines starting with this comment character are skipped
     #[arg(short = 'C', long = "comment-char", default_value = "#")]
     pub comment_char: String,
 
+    /// Ignore rows where every field is empty/whitespace
     #[arg(short = 'E', long = "ignore-empty-row")]
     pub ignore_empty_row: bool,
 
+    /// Ignore rows whose column count differs from the header/first row
     #[arg(short = 'I', long = "ignore-illegal-row")]
     pub ignore_illegal_row: bool,
 }


### PR DESCRIPTION
### Motivation
- Improve discoverability and usability by enriching subcommand `long_about`/`after_help` messages with examples, tips, and option notes. 
- Clarify common workflows and option semantics for users (headers, comment handling, join modes, pivot/melt round-trips, Excel import/export, etc.).
- Keep runtime behavior unchanged while making the CLI self-documenting for interactive use and help pages.

### Description
- Expanded and standardized help text (`long_about`/`after_help`) for many modules including `csv`, `excel`, `filter`, `head`, `info`, `join`, `cut`, `melt`, `mutate`, `pivot`, `pretty`, `slice`, `sort`, `summarize`, `transpose`, and top-level `main.rs` to add examples, notes, and tips. 
- Added/clarified argument doc comments for several `Args` fields (examples: `HeadArgs.files`, `HeadArgs.lines`, and other flag descriptions) so generated CLI help is more informative. 
- Minor formatting change in `head.rs` to simplify a `writeln!` call (no logic change). 
- No change to core parsing, file I/O, or data-processing logic; edits are focused on user-facing documentation strings and CLI metadata.

### Testing
- Ran `cargo build` to verify the project compiles successfully after the documentation edits. 
- Ran the existing test suite with `cargo test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cdecf2e4832a9787676710936f08)