### PR TITLE
Add rename/separate/unite subcommands; improve filter divide-by-zero diagnostics and CSV default input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "tsvkit"
-version = "0.9.10"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsvkit"
-version = "0.9.10"
+version = "0.9.12"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
   - [`transpose`](#transpose)
   - [`excel`](#excel)
   - [`csv`](#csv)
+  - [`rename`](#rename)
+  - [`separate`](#separate)
+  - [`unite`](#unite)
 - [Additional tips](#additional-tips)
 
 ## Overview
@@ -111,6 +114,9 @@ The list below provides a one-line description of every `tsvkit` subcommand. Eac
 - [`transpose`](#transpose) — transpose rows and columns.
 - [`excel`](#excel) — inspect, preview, export, or build `.xlsx` workbooks.
 - [`csv`](#csv) — convert delimited text to TSV with custom separators.
+- [`rename`](#rename) — rename header columns via selector assignments.
+- [`separate`](#separate) — split one character column into multiple columns.
+- [`unite`](#unite) — combine multiple columns into one character column.
 
 ## Core concepts
 These conventions appear across the toolkit; understanding them once makes each subcommand predictable.
@@ -322,6 +328,8 @@ Case helpers are supported in filter expressions:
 tsvkit filter -e 'cap($1) == "HELLO"' data.tsv
 tsvkit filter -e 'upper($group) == "CASE"' examples/samples.tsv
 ```
+
+If any `/` denominator evaluates to exactly `0`, `filter` emits a warning to stderr with the affected row count and a suggested guard (for example `$col!=0` or `$col>0`).
 
 **Expression building blocks for `filter`**
 
@@ -676,6 +684,51 @@ Compressed inputs work via the same auto-detection as other commands.
 tsvkit csv examples/data.csv > examples/data.tsv
 tsvkit csv examples/semicolon.csv --delim ';' -H > tmp.tsv
 ```
+
+### `rename`
+Rename header columns without modifying row values.
+
+```bash
+tsvkit rename -e 'sample_id=id;group=cohort' examples/samples.tsv
+tsvkit rename -e '1,3,sample_id=["id","visit","sample"]' examples/samples.tsv
+tsvkit rename -e ':=["id","subject","arm","visit","purity","dna","rna","contam","tech"]' examples/samples.tsv
+```
+
+Notes:
+- Selectors use normal selector syntax (`name`, `1`, `2:5`, `~"regex"`); **do not** prefix with `$`.
+- For `selectors=[...]`, the number of replacement names must match the number of selected columns.
+- `:=...` replaces the full header list in order.
+
+For headerless inputs, pass `-H` and provide all column names:
+
+```bash
+cat no_header.tsv | tsvkit rename -H -e ':=c1,c2,c3'
+```
+
+### `separate`
+Split one character column into multiple columns by delimiter text or regex.
+
+```bash
+tsvkit separate -f sample_id --into subject,visit --sep '-' examples/samples.tsv
+tsvkit separate -f barcode --into part1,part2 --regex-sep '\\|' data.tsv
+```
+
+Defaults:
+- If `--into` is omitted, output names default to `<source>_1,<source>_2`.
+- By default the source column is replaced; use `--keep` to retain it.
+
+### `unite`
+Combine selected columns into one output column.
+
+```bash
+tsvkit unite -f subject_id,timepoint --name subject_time --sep '_' examples/samples.tsv
+tsvkit unite -f '1:3' --name key --sep '|' -H data.tsv
+```
+
+Defaults:
+- Output name defaults to `united`.
+- Selected source columns are removed unless `--keep` is provided.
+- Use `--na-rm` to skip empty pieces while joining.
 
 ## Additional tips
 - `tsvkit` automatically detects `.tsv`, `.tsv.gz`, and `.tsv.xz`. Pipe from `curl`/`zcat` for other formats.

--- a/src/csv/mod.rs
+++ b/src/csv/mod.rs
@@ -28,7 +28,7 @@ Option notes:
 )]
 pub struct CsvArgs {
     /// Input CSV file (use '-' for stdin; gz/xz supported)
-    #[arg(value_name = "FILE", required = true)]
+    #[arg(value_name = "FILE", default_value = "-")]
     pub input: PathBuf,
 
     /// CSV delimiter character (default ',')

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
@@ -290,22 +291,29 @@ pub struct EvalValue<'a> {
     pub numeric: Option<f64>,
 }
 
+#[derive(Debug, Default, Clone)]
+pub struct EvalDiagnostics {
+    pub divide_by_zero_count: usize,
+}
+
 pub struct EvalContext<'a, R>
 where
     R: RowAccessor + ?Sized,
 {
     row: &'a R,
     regex_captures: Option<Vec<String>>,
+    diagnostics: Option<&'a mut EvalDiagnostics>,
 }
 
 impl<'a, R> EvalContext<'a, R>
 where
     R: RowAccessor + ?Sized,
 {
-    pub fn new(row: &'a R) -> Self {
+    pub fn new(row: &'a R, diagnostics: Option<&'a mut EvalDiagnostics>) -> Self {
         EvalContext {
             row,
             regex_captures: None,
+            diagnostics,
         }
     }
 
@@ -328,13 +336,32 @@ where
     fn restore_captures(&mut self, captures: Option<Vec<String>>) {
         self.regex_captures = captures;
     }
+
+    fn note_division_by_zero(&mut self) {
+        if let Some(diag) = self.diagnostics.as_deref_mut() {
+            diag.divide_by_zero_count += 1;
+        }
+    }
 }
 
+#[allow(dead_code)]
 pub fn evaluate<R>(expr: &BoundExpr, row: &R) -> bool
 where
     R: RowAccessor + ?Sized,
 {
-    let mut ctx = EvalContext::new(row);
+    let mut ctx = EvalContext::new(row, None);
+    evaluate_with_context(expr, &mut ctx)
+}
+
+pub fn evaluate_with_diagnostics<R>(
+    expr: &BoundExpr,
+    row: &R,
+    diagnostics: &mut EvalDiagnostics,
+) -> bool
+where
+    R: RowAccessor + ?Sized,
+{
+    let mut ctx = EvalContext::new(row, Some(diagnostics));
     evaluate_with_context(expr, &mut ctx)
 }
 
@@ -364,7 +391,7 @@ pub fn eval_value<'a, R>(value: &'a BoundValue, row: &'a R) -> EvalValue<'a>
 where
     R: RowAccessor + ?Sized,
 {
-    let mut ctx = EvalContext::new(row);
+    let mut ctx = EvalContext::new(row, None);
     eval_value_with_context(value, &mut ctx)
 }
 
@@ -439,7 +466,8 @@ where
                     BinaryOp::Sub => numeric_eval(a - b),
                     BinaryOp::Mul => numeric_eval(a * b),
                     BinaryOp::Div => {
-                        if b.abs() < f64::EPSILON {
+                        if b == 0.0 {
+                            ctx.note_division_by_zero();
                             empty_eval()
                         } else {
                             numeric_eval(a / b)
@@ -662,8 +690,100 @@ pub fn evaluate_truthy<'a, R>(value: &'a BoundValue, row: &'a R) -> bool
 where
     R: RowAccessor + ?Sized,
 {
-    let mut ctx = EvalContext::new(row);
+    let mut ctx = EvalContext::new(row, None);
     evaluate_truthy_with_context(value, &mut ctx)
+}
+
+pub fn collect_division_denominator_columns(expr: &BoundExpr) -> Vec<usize> {
+    let mut out = HashSet::new();
+    collect_div_cols_expr(expr, &mut out);
+    let mut cols = out.into_iter().collect::<Vec<_>>();
+    cols.sort_unstable();
+    cols
+}
+
+fn collect_div_cols_expr(expr: &BoundExpr, out: &mut HashSet<usize>) {
+    match expr {
+        BoundExpr::Or(lhs, rhs) | BoundExpr::And(lhs, rhs) => {
+            collect_div_cols_expr(lhs, out);
+            collect_div_cols_expr(rhs, out);
+        }
+        BoundExpr::Not(inner) => collect_div_cols_expr(inner, out),
+        BoundExpr::Compare(lhs, _, rhs) => {
+            collect_div_cols_value(lhs, out);
+            collect_div_cols_value(rhs, out);
+        }
+        BoundExpr::RegexMatch { value, .. } | BoundExpr::Value(value) => {
+            collect_div_cols_value(value, out)
+        }
+    }
+}
+
+fn collect_div_cols_value(value: &BoundValue, out: &mut HashSet<usize>) {
+    match value {
+        BoundValue::Unary(_, inner) | BoundValue::Function(_, inner) => {
+            collect_div_cols_value(inner, out)
+        }
+        BoundValue::Binary(BinaryOp::Div, left, right) => {
+            collect_div_cols_value(left, out);
+            match &**right {
+                BoundValue::Column(idx) => {
+                    out.insert(*idx);
+                }
+                BoundValue::Columns(indices) => {
+                    for idx in indices {
+                        out.insert(*idx);
+                    }
+                }
+                other => collect_div_cols_value(other, out),
+            }
+        }
+        BoundValue::Binary(_, left, right) => {
+            collect_div_cols_value(left, out);
+            collect_div_cols_value(right, out);
+        }
+        BoundValue::CaseWhen { branches, default } => {
+            for (cond, result) in branches {
+                collect_div_cols_expr(cond, out);
+                collect_div_cols_value(result, out);
+            }
+            if let Some(default) = default {
+                collect_div_cols_value(default, out);
+            }
+        }
+        BoundValue::Switch {
+            target,
+            branches,
+            default,
+        } => {
+            collect_div_cols_value(target, out);
+            for (vals, result) in branches {
+                for v in vals {
+                    collect_div_cols_value(v, out);
+                }
+                collect_div_cols_value(result, out);
+            }
+            if let Some(default) = default {
+                collect_div_cols_value(default, out);
+            }
+        }
+        BoundValue::RegexCall { value, pattern } => {
+            collect_div_cols_value(value, out);
+            if let RegexPattern::Dynamic(v) = pattern {
+                collect_div_cols_value(v, out);
+            }
+        }
+        BoundValue::List(items) => {
+            for item in items {
+                collect_div_cols_value(item, out);
+            }
+        }
+        BoundValue::Column(_)
+        | BoundValue::Columns(_)
+        | BoundValue::String(_)
+        | BoundValue::Number(_)
+        | BoundValue::Aggregate(_) => {}
+    }
 }
 
 fn evaluate_compare<'a, R>(
@@ -1142,6 +1262,29 @@ mod tests {
         let row: Vec<String> = Vec::new();
         let eval = eval_value(&bound, &row);
         assert_eq!(eval.numeric, Some(512.0));
+    }
+
+    #[test]
+    fn division_keeps_non_zero_tiny_denominator() {
+        let expr = parse_expression("($1/$2) > 1").unwrap();
+        let headers = vec!["a".to_string(), "b".to_string()];
+        let bound = bind_expression(expr, &headers, false).unwrap();
+        let row = vec!["1".to_string(), "1e-30".to_string()];
+        assert!(evaluate(&bound, &row));
+    }
+
+    #[test]
+    fn collects_division_denominator_columns() {
+        let expr = parse_expression("($1/$2)>0 & ($3/$4)>0").unwrap();
+        let headers = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ];
+        let bound = bind_expression(expr, &headers, false).unwrap();
+        let cols = collect_division_denominator_columns(&bound);
+        assert_eq!(cols, vec![1, 3]);
     }
 
     #[test]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -5,7 +5,10 @@ use anyhow::{Context, Result};
 use clap::Args;
 
 use crate::common::{InputOptions, default_headers, reader_for_path, should_skip_record};
-use crate::expression::{bind_expression, evaluate, parse_expression};
+use crate::expression::{
+    EvalDiagnostics, bind_expression, collect_division_denominator_columns,
+    evaluate_with_diagnostics, parse_expression,
+};
 
 #[derive(Args, Debug)]
 #[command(
@@ -90,8 +93,14 @@ pub fn run(args: FilterArgs) -> Result<()> {
         };
         let headers = default_headers(first_record.len());
         let bound = bind_expression(expr_ast, &headers, true)?;
+        let denominator_cols = collect_division_denominator_columns(&bound);
+        let mut zero_den_rows = 0usize;
+        let mut eval_diag = EvalDiagnostics::default();
 
-        if evaluate(&bound, &first_record) {
+        if row_has_zero_denominator(&first_record, &denominator_cols) {
+            zero_den_rows += 1;
+        }
+        if evaluate_with_diagnostics(&bound, &first_record, &mut eval_diag) {
             emit_record(&first_record, &mut writer)?;
         }
         let expected_width = first_record.len();
@@ -100,10 +109,20 @@ pub fn run(args: FilterArgs) -> Result<()> {
             if should_skip_record(&record, &input_opts, Some(expected_width)) {
                 continue;
             }
-            if evaluate(&bound, &record) {
+            if row_has_zero_denominator(&record, &denominator_cols) {
+                zero_den_rows += 1;
+            }
+            if evaluate_with_diagnostics(&bound, &record, &mut eval_diag) {
                 emit_record(&record, &mut writer)?;
             }
         }
+        emit_division_warning(
+            zero_den_rows,
+            &denominator_cols,
+            &headers,
+            true,
+            eval_diag.divide_by_zero_count,
+        );
     } else {
         let headers = reader
             .headers()
@@ -112,15 +131,21 @@ pub fn run(args: FilterArgs) -> Result<()> {
             .map(|s| s.to_string())
             .collect::<Vec<_>>();
         let bound = bind_expression(expr_ast, &headers, false)?;
+        let denominator_cols = collect_division_denominator_columns(&bound);
         let expected_width = headers.len();
         let header_line = (!headers.is_empty()).then(|| headers.join("\t"));
         let mut header_written = false;
+        let mut zero_den_rows = 0usize;
+        let mut eval_diag = EvalDiagnostics::default();
         for record in reader.records() {
             let record = record.with_context(|| format!("failed reading from {:?}", args.file))?;
             if should_skip_record(&record, &input_opts, Some(expected_width)) {
                 continue;
             }
-            if evaluate(&bound, &record) {
+            if row_has_zero_denominator(&record, &denominator_cols) {
+                zero_den_rows += 1;
+            }
+            if evaluate_with_diagnostics(&bound, &record, &mut eval_diag) {
                 if !header_written {
                     if let Some(line) = header_line.as_ref() {
                         writeln!(writer, "{}", line)?;
@@ -130,10 +155,59 @@ pub fn run(args: FilterArgs) -> Result<()> {
                 emit_record(&record, &mut writer)?;
             }
         }
+        emit_division_warning(
+            zero_den_rows,
+            &denominator_cols,
+            &headers,
+            false,
+            eval_diag.divide_by_zero_count,
+        );
     }
 
     writer.flush()?;
     Ok(())
+}
+
+fn row_has_zero_denominator(record: &csv::StringRecord, columns: &[usize]) -> bool {
+    columns.iter().any(|&idx| {
+        record
+            .get(idx)
+            .and_then(|value| value.trim().parse::<f64>().ok())
+            .map(|v| v == 0.0)
+            .unwrap_or(false)
+    })
+}
+
+fn emit_division_warning(
+    zero_den_rows: usize,
+    denominator_cols: &[usize],
+    headers: &[String],
+    no_header: bool,
+    divide_by_zero_count: usize,
+) {
+    if zero_den_rows == 0 || denominator_cols.is_empty() {
+        return;
+    }
+    let selector_text = denominator_cols
+        .iter()
+        .map(|idx| {
+            if no_header {
+                format!("${}", idx + 1)
+            } else {
+                let name = headers.get(*idx).map(|s| s.as_str()).unwrap_or("");
+                format!("${{{}}}", name)
+            }
+        })
+        .collect::<Vec<_>>();
+    let guard = selector_text
+        .iter()
+        .map(|s| format!("{}!=0", s))
+        .collect::<Vec<_>>()
+        .join(" & ");
+    eprintln!(
+        "warning: encountered {} row(s) with denominator value exactly zero while evaluating filter ({} divide-by-zero evaluation(s)). Consider adding a guard such as: {}",
+        zero_den_rows, divide_by_zero_count, guard
+    );
 }
 
 fn emit_record(

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,10 +17,13 @@ mod melt;
 mod mutate;
 mod pivot;
 mod pretty;
+mod rename;
+mod separate;
 mod slice;
 mod sort;
 mod summarize;
 mod transpose;
+mod unite;
 
 #[derive(Parser)]
 #[command(
@@ -61,6 +64,12 @@ enum Commands {
     Transpose(transpose::TransposeArgs),
     /// Slice rows by 1-based index/ranges (supports from-end selectors)
     Slice(slice::SliceArgs),
+    /// Rename header columns using selector assignments
+    Rename(rename::RenameArgs),
+    /// Split one character column into multiple columns
+    Separate(separate::SeparateArgs),
+    /// Combine multiple character columns into one column
+    Unite(unite::UniteArgs),
     /// Excel helpers: inspect sheets, preview, dump TSV, or load TSV into xlsx
     Excel(excel::ExcelArgs),
     /// CSV utilities (convert CSV/TSV-like delimited text into TSV)
@@ -85,6 +94,9 @@ fn main() -> Result<()> {
         Commands::Head(args) => head::run(args),
         Commands::Transpose(args) => transpose::run(args),
         Commands::Slice(args) => slice::run(args),
+        Commands::Rename(args) => rename::run(args),
+        Commands::Separate(args) => separate::run(args),
+        Commands::Unite(args) => unite::run(args),
         Commands::Excel(args) => excel::run(args, &raw_args),
         Commands::Csv(args) => csv::run(args),
         Commands::Info(args) => info::run(args),

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -1,0 +1,322 @@
+use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+
+use crate::common::{
+    InputOptions, default_headers, parse_selector_list, reader_for_path, resolve_selectors,
+    should_skip_record,
+};
+
+#[derive(Args, Debug)]
+#[command(
+    about = "Rename header columns",
+    long_about = "Rename header columns by selector assignment. Use `old=new` mappings separated by semicolons (e.g. `sample_id=id;group=cohort`) or map selector lists to name lists (`1,3,sample=[\"col1\",\"col3\",\"sample\"]`). You can also replace the entire header with `:=` (e.g. `:= [\"c1\",\"c2\"]`; `1:=...` is accepted as an alias). Selectors use normal tsvkit selector syntax (no `$` prefix).",
+    after_help = "Examples:
+  tsvkit rename -e 'sample_id=id;group=cohort' data.tsv
+  tsvkit rename -e '1,3,sample=[\"col1\",\"col3\",\"sample\"]' data.tsv
+  tsvkit rename -e ':=[\"newname1\",\"newname2\",\"newname3\"]' data.tsv
+  tsvkit rename -H -e ':=col1,col2,col3' no_header_input.tsv"
+)]
+pub struct RenameArgs {
+    /// Input TSV file (use '-' for stdin; gz/xz supported)
+    #[arg(value_name = "FILE", default_value = "-")]
+    pub file: PathBuf,
+
+    /// Rename expression(s): `old=new`, `selectors=[n1,n2,...]`, and/or `:=["h1","h2",...]`
+    #[arg(short = 'e', long = "expr", value_name = "EXPR", required = true)]
+    pub expr: String,
+
+    /// Treat input as headerless and create headers from --expr
+    #[arg(short = 'H', long = "no-header")]
+    pub no_header: bool,
+
+    /// Lines starting with this comment character are skipped (set to an uncommon symbol if your header begins with '#')
+    #[arg(
+        short = 'C',
+        long = "comment-char",
+        value_name = "CHAR",
+        default_value = "#"
+    )]
+    pub comment_char: String,
+
+    /// Ignore rows where every field is empty/whitespace
+    #[arg(short = 'E', long = "ignore-empty-row")]
+    pub ignore_empty_row: bool,
+
+    /// Ignore rows whose column count differs from the header/first row
+    #[arg(short = 'I', long = "ignore-illegal-row")]
+    pub ignore_illegal_row: bool,
+}
+
+pub fn run(args: RenameArgs) -> Result<()> {
+    let input_opts = InputOptions::from_flags(
+        &args.comment_char,
+        args.ignore_empty_row,
+        args.ignore_illegal_row,
+    )?;
+    let mut reader = reader_for_path(&args.file, args.no_header, &input_opts)?;
+    let mut writer = BufWriter::new(io::stdout().lock());
+
+    if args.no_header {
+        let mut records = reader.records();
+        let first_record = loop {
+            match records.next() {
+                Some(rec) => {
+                    let record =
+                        rec.with_context(|| format!("failed reading from {:?}", args.file))?;
+                    if should_skip_record(&record, &input_opts, None) {
+                        continue;
+                    }
+                    break record;
+                }
+                None => return Ok(()),
+            }
+        };
+        let expected_width = first_record.len();
+        let mut headers = default_headers(expected_width);
+        apply_rename_expr(&mut headers, &args.expr, true)?;
+        writeln!(writer, "{}", headers.join("\t"))?;
+        writeln!(
+            writer,
+            "{}",
+            first_record.iter().collect::<Vec<_>>().join("\t")
+        )?;
+        for record in records {
+            let record = record.with_context(|| format!("failed reading from {:?}", args.file))?;
+            if should_skip_record(&record, &input_opts, Some(expected_width)) {
+                continue;
+            }
+            writeln!(writer, "{}", record.iter().collect::<Vec<_>>().join("\t"))?;
+        }
+    } else {
+        let headers = reader
+            .headers()
+            .with_context(|| format!("failed reading header from {:?}", args.file))?
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        let expected_width = headers.len();
+        let mut renamed = headers.clone();
+        apply_rename_expr(&mut renamed, &args.expr, false)?;
+        writeln!(writer, "{}", renamed.join("\t"))?;
+        for record in reader.records() {
+            let record = record.with_context(|| format!("failed reading from {:?}", args.file))?;
+            if should_skip_record(&record, &input_opts, Some(expected_width)) {
+                continue;
+            }
+            writeln!(writer, "{}", record.iter().collect::<Vec<_>>().join("\t"))?;
+        }
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
+fn apply_rename_expr(headers: &mut Vec<String>, expr: &str, no_header: bool) -> Result<()> {
+    let clauses = split_clauses(expr)?;
+    if clauses.is_empty() {
+        bail!("rename expression must not be empty");
+    }
+
+    for clause in clauses {
+        if let Some((left, right)) = clause.split_once(":=") {
+            let lhs = left.trim();
+            if !(lhs.is_empty() || lhs == ":" || lhs == "1") {
+                bail!("`:=` assignment only supports ':=' or '1:=' on the left-hand side");
+            }
+            let names = parse_header_list(right)?;
+            if names.len() != headers.len() {
+                bail!(
+                    "header list contains {} names but input has {} columns",
+                    names.len(),
+                    headers.len()
+                );
+            }
+            *headers = names;
+            continue;
+        }
+
+        let Some((left, right)) = clause.split_once('=') else {
+            bail!(
+                "invalid rename clause '{}': expected selector=new_name",
+                clause
+            );
+        };
+        let selectors = parse_selector_list(left.trim())?;
+        let indices = resolve_selectors(headers, &selectors, no_header)?;
+        if indices.is_empty() {
+            bail!("selector '{}' resolved to no columns", left.trim());
+        }
+        let rhs = right.trim();
+        if rhs.is_empty() {
+            bail!("new header name must not be empty");
+        }
+        let names = parse_multi_names(rhs)?;
+        if names.len() == 1 {
+            for idx in indices {
+                headers[idx] = names[0].clone();
+            }
+        } else {
+            if names.len() != indices.len() {
+                bail!(
+                    "selector '{}' resolves to {} columns, but {} replacement names were provided",
+                    left.trim(),
+                    indices.len(),
+                    names.len()
+                );
+            }
+            for (idx, name) in indices.into_iter().zip(names.into_iter()) {
+                headers[idx] = name;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn split_clauses(expr: &str) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut bracket_depth = 0usize;
+    let mut prev_escape = false;
+
+    for ch in expr.chars() {
+        match ch {
+            '\'' if !in_double && !prev_escape => in_single = !in_single,
+            '"' if !in_single && !prev_escape => in_double = !in_double,
+            '[' if !in_single && !in_double => bracket_depth += 1,
+            ']' if !in_single && !in_double && bracket_depth > 0 => bracket_depth -= 1,
+            ';' if !in_single && !in_double && bracket_depth == 0 => {
+                let trimmed = current.trim();
+                if !trimmed.is_empty() {
+                    out.push(trimmed.to_string());
+                }
+                current.clear();
+                prev_escape = false;
+                continue;
+            }
+            _ => {}
+        }
+        current.push(ch);
+        prev_escape = ch == '\\' && !prev_escape;
+    }
+
+    if in_single || in_double || bracket_depth != 0 {
+        bail!("unterminated quote or bracket in rename expression");
+    }
+
+    let trimmed = current.trim();
+    if !trimmed.is_empty() {
+        out.push(trimmed.to_string());
+    }
+    Ok(out)
+}
+
+fn parse_header_list(raw: &str) -> Result<Vec<String>> {
+    let trimmed = raw.trim();
+    let inner = if trimmed.starts_with('[') && trimmed.ends_with(']') && trimmed.len() >= 2 {
+        &trimmed[1..trimmed.len() - 1]
+    } else {
+        trimmed
+    };
+    let parts = split_csv_like(inner)?;
+    if parts.is_empty() {
+        bail!("header list must not be empty");
+    }
+    Ok(parts)
+}
+
+fn parse_multi_names(raw: &str) -> Result<Vec<String>> {
+    let names = parse_header_list(raw)?;
+    if names.iter().any(|name| name.trim().is_empty()) {
+        bail!("replacement names must not be empty");
+    }
+    Ok(names)
+}
+
+fn split_csv_like(input: &str) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut prev_escape = false;
+
+    for ch in input.chars() {
+        match ch {
+            '\'' if !in_double && !prev_escape => in_single = !in_single,
+            '"' if !in_single && !prev_escape => in_double = !in_double,
+            ',' if !in_single && !in_double => {
+                let value = trim_quotes(current.trim())?;
+                if !value.is_empty() {
+                    out.push(value);
+                }
+                current.clear();
+                prev_escape = false;
+                continue;
+            }
+            _ => {}
+        }
+        current.push(ch);
+        prev_escape = ch == '\\' && !prev_escape;
+    }
+    if in_single || in_double {
+        bail!("unterminated quote in header list");
+    }
+    let value = trim_quotes(current.trim())?;
+    if !value.is_empty() {
+        out.push(value);
+    }
+    Ok(out)
+}
+
+fn trim_quotes(value: &str) -> Result<String> {
+    if value.is_empty() {
+        return Ok(String::new());
+    }
+    if (value.starts_with('"') && value.ends_with('"'))
+        || (value.starts_with('\'') && value.ends_with('\''))
+    {
+        if value.len() < 2 {
+            bail!("invalid quoted header name");
+        }
+        return Ok(value[1..value.len() - 1].to_string());
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rename_mapping_and_bulk_replace() {
+        let mut headers = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        apply_rename_expr(&mut headers, "a=alpha;c=gamma", false).unwrap();
+        assert_eq!(headers, vec!["alpha", "b", "gamma"]);
+
+        apply_rename_expr(&mut headers, ":=[\"x\",\"y\",\"z\"]", false).unwrap();
+        assert_eq!(headers, vec!["x", "y", "z"]);
+    }
+
+    #[test]
+    fn selector_list_can_map_to_name_list() {
+        let mut headers = vec![
+            "col1".to_string(),
+            "col2".to_string(),
+            "sample".to_string(),
+            "col4".to_string(),
+        ];
+        apply_rename_expr(&mut headers, "1,3,sample=[\"a\",\"b\",\"c\"]", false).unwrap();
+        assert_eq!(headers, vec!["a", "col2", "c", "col4"]);
+    }
+
+    #[test]
+    fn split_clauses_handles_lists() {
+        let parts = split_clauses("a=x; :=[\"b;c\",d]").unwrap();
+        assert_eq!(parts, vec!["a=x", ":=[\"b;c\",d]"]);
+    }
+}

--- a/src/separate.rs
+++ b/src/separate.rs
@@ -1,0 +1,294 @@
+use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use regex::Regex;
+
+use crate::common::{
+    InputOptions, default_headers, parse_selector_list, reader_for_path, resolve_selectors,
+    should_skip_record,
+};
+
+#[derive(Args, Debug)]
+#[command(
+    about = "Split one column into multiple columns",
+    long_about = "Split a character column into multiple output columns by separator text (or regex with --regex-sep). By default, the source column is replaced by the new columns. Use --keep to retain the original column too.",
+    after_help = "Examples:
+  tsvkit separate -f sample_id --into subject,visit --sep '-' data.tsv
+  tsvkit separate -f 1 --into id,run,lane --sep '_' -H data.tsv
+  tsvkit separate -f barcode --into part1,part2 --regex-sep '\\\\|' data.tsv"
+)]
+pub struct SeparateArgs {
+    /// Input TSV file (use '-' for stdin; gz/xz supported)
+    #[arg(value_name = "FILE", default_value = "-")]
+    pub file: PathBuf,
+
+    /// Source column selector (must resolve to exactly one column)
+    #[arg(short = 'f', long = "field", value_name = "SELECTOR", required = true)]
+    pub field: String,
+
+    /// Output column names (comma-separated). If omitted, defaults to source_1, source_2, ...
+    #[arg(long = "into", value_name = "NAMES")]
+    pub into: Option<String>,
+
+    /// Separator string (literal by default, regex if --regex-sep is set)
+    #[arg(long = "sep", value_name = "SEP", default_value = "_")]
+    pub sep: String,
+
+    /// Interpret --sep as a regex pattern
+    #[arg(long = "regex-sep")]
+    pub regex_sep: bool,
+
+    /// Keep source column instead of replacing it
+    #[arg(long = "keep")]
+    pub keep: bool,
+
+    /// Treat input as headerless
+    #[arg(short = 'H', long = "no-header")]
+    pub no_header: bool,
+
+    #[arg(
+        short = 'C',
+        long = "comment-char",
+        value_name = "CHAR",
+        default_value = "#"
+    )]
+    pub comment_char: String,
+    #[arg(short = 'E', long = "ignore-empty-row")]
+    pub ignore_empty_row: bool,
+    #[arg(short = 'I', long = "ignore-illegal-row")]
+    pub ignore_illegal_row: bool,
+}
+
+pub fn run(args: SeparateArgs) -> Result<()> {
+    let input_opts = InputOptions::from_flags(
+        &args.comment_char,
+        args.ignore_empty_row,
+        args.ignore_illegal_row,
+    )?;
+    let mut reader = reader_for_path(&args.file, args.no_header, &input_opts)?;
+    let mut writer = BufWriter::new(io::stdout().lock());
+
+    let splitter = if args.regex_sep {
+        Splitter::Regex(
+            Regex::new(&args.sep)
+                .with_context(|| format!("invalid --sep regex pattern '{}'", args.sep))?,
+        )
+    } else {
+        Splitter::Literal(args.sep.clone())
+    };
+
+    if args.no_header {
+        let mut records = reader.records();
+        let first_record = loop {
+            match records.next() {
+                Some(rec) => {
+                    let record =
+                        rec.with_context(|| format!("failed reading from {:?}", args.file))?;
+                    if should_skip_record(&record, &input_opts, None) {
+                        continue;
+                    }
+                    break record;
+                }
+                None => return Ok(()),
+            }
+        };
+        let expected_width = first_record.len();
+        let headers = default_headers(expected_width);
+        let selected = parse_selector_list(&args.field)?;
+        let idx = resolve_single_column(&headers, &selected, true)?;
+        let into_names = resolve_into_names(args.into.as_deref(), headers[idx].as_str())?;
+        let output_header = build_output_header(&headers, idx, &into_names, args.keep);
+        writeln!(writer, "{}", output_header.join("\t"))?;
+
+        let row = transform_row(
+            first_record.iter().map(|s| s.to_string()).collect(),
+            idx,
+            &into_names,
+            &splitter,
+            args.keep,
+        );
+        writeln!(writer, "{}", row.join("\t"))?;
+
+        for record in records {
+            let record = record.with_context(|| format!("failed reading from {:?}", args.file))?;
+            if should_skip_record(&record, &input_opts, Some(expected_width)) {
+                continue;
+            }
+            let row = transform_row(
+                record.iter().map(|s| s.to_string()).collect(),
+                idx,
+                &into_names,
+                &splitter,
+                args.keep,
+            );
+            writeln!(writer, "{}", row.join("\t"))?;
+        }
+    } else {
+        let headers = reader
+            .headers()
+            .with_context(|| format!("failed reading header from {:?}", args.file))?
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        let expected_width = headers.len();
+        let selected = parse_selector_list(&args.field)?;
+        let idx = resolve_single_column(&headers, &selected, false)?;
+        let into_names = resolve_into_names(args.into.as_deref(), headers[idx].as_str())?;
+        let output_header = build_output_header(&headers, idx, &into_names, args.keep);
+        writeln!(writer, "{}", output_header.join("\t"))?;
+
+        for record in reader.records() {
+            let record = record.with_context(|| format!("failed reading from {:?}", args.file))?;
+            if should_skip_record(&record, &input_opts, Some(expected_width)) {
+                continue;
+            }
+            let row = transform_row(
+                record.iter().map(|s| s.to_string()).collect(),
+                idx,
+                &into_names,
+                &splitter,
+                args.keep,
+            );
+            writeln!(writer, "{}", row.join("\t"))?;
+        }
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
+enum Splitter {
+    Literal(String),
+    Regex(Regex),
+}
+
+fn resolve_single_column(
+    headers: &[String],
+    selectors: &[crate::common::ColumnSelector],
+    no_header: bool,
+) -> Result<usize> {
+    let indices = resolve_selectors(headers, selectors, no_header)?;
+    if indices.len() != 1 {
+        bail!(
+            "--field must resolve to exactly one column, got {}",
+            indices.len()
+        );
+    }
+    Ok(indices[0])
+}
+
+fn resolve_into_names(spec: Option<&str>, source_name: &str) -> Result<Vec<String>> {
+    match spec {
+        Some(text) if !text.trim().is_empty() => text
+            .split(',')
+            .map(|x| x.trim().to_string())
+            .filter(|x| !x.is_empty())
+            .collect::<Vec<_>>()
+            .pipe(|names| {
+                if names.is_empty() {
+                    bail!("--into must provide at least one output name")
+                } else {
+                    Ok(names)
+                }
+            }),
+        _ => Ok(vec![
+            format!("{}_1", source_name),
+            format!("{}_2", source_name),
+        ]),
+    }
+}
+
+fn build_output_header(
+    headers: &[String],
+    source_idx: usize,
+    into_names: &[String],
+    keep_source: bool,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for (idx, name) in headers.iter().enumerate() {
+        if idx == source_idx {
+            if keep_source {
+                out.push(name.clone());
+            }
+            out.extend(into_names.iter().cloned());
+        } else {
+            out.push(name.clone());
+        }
+    }
+    out
+}
+
+fn transform_row(
+    row: Vec<String>,
+    source_idx: usize,
+    into_names: &[String],
+    splitter: &Splitter,
+    keep_source: bool,
+) -> Vec<String> {
+    let source = row.get(source_idx).cloned().unwrap_or_default();
+    let split = split_value(&source, into_names.len(), splitter);
+    let mut out = Vec::new();
+    for (idx, value) in row.into_iter().enumerate() {
+        if idx == source_idx {
+            if keep_source {
+                out.push(value);
+            }
+            out.extend(split.iter().cloned());
+        } else {
+            out.push(value);
+        }
+    }
+    out
+}
+
+fn split_value(value: &str, parts: usize, splitter: &Splitter) -> Vec<String> {
+    let mut out = Vec::new();
+    if parts == 0 {
+        return out;
+    }
+    match splitter {
+        Splitter::Literal(sep) => {
+            for token in value.splitn(parts, sep) {
+                out.push(token.to_string());
+            }
+        }
+        Splitter::Regex(re) => {
+            for token in re.splitn(value, parts) {
+                out.push(token.to_string());
+            }
+        }
+    }
+    while out.len() < parts {
+        out.push(String::new());
+    }
+    out
+}
+
+trait Pipe: Sized {
+    fn pipe<F, T>(self, f: F) -> T
+    where
+        F: FnOnce(Self) -> T,
+    {
+        f(self)
+    }
+}
+impl<T> Pipe for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_value_pads_missing_parts() {
+        let parts = split_value("A", 3, &Splitter::Literal("_".to_string()));
+        assert_eq!(parts, vec!["A", "", ""]);
+    }
+
+    #[test]
+    fn split_value_limits_to_requested_parts() {
+        let parts = split_value("A_B_C_D", 3, &Splitter::Literal("_".to_string()));
+        assert_eq!(parts, vec!["A", "B", "C_D"]);
+    }
+}

--- a/src/unite.rs
+++ b/src/unite.rs
@@ -1,0 +1,231 @@
+use std::collections::HashSet;
+use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+
+use crate::common::{
+    InputOptions, default_headers, parse_selector_list, reader_for_path, resolve_selectors,
+    should_skip_record,
+};
+
+#[derive(Args, Debug)]
+#[command(
+    about = "Combine multiple columns into one column",
+    long_about = "Combine values from selected columns into one output column separated by text. By default selected source columns are removed; use --keep to keep them.",
+    after_help = "Examples:
+  tsvkit unite -f subject_id,timepoint --name subject_time --sep '_' data.tsv
+  tsvkit unite -H -f '1:3' --name key --sep '|' data.tsv"
+)]
+pub struct UniteArgs {
+    /// Input TSV file (use '-' for stdin; gz/xz supported)
+    #[arg(value_name = "FILE", default_value = "-")]
+    pub file: PathBuf,
+
+    /// Source column selectors to combine (supports mixed names/indices/ranges/regex)
+    #[arg(
+        short = 'f',
+        long = "fields",
+        value_name = "SELECTORS",
+        required = true
+    )]
+    pub fields: String,
+
+    /// Name of the output combined column (default: united)
+    #[arg(long = "name", value_name = "NAME", default_value = "united")]
+    pub name: String,
+
+    /// Separator inserted between source values
+    #[arg(long = "sep", value_name = "SEP", default_value = "_")]
+    pub sep: String,
+
+    /// Keep source columns instead of replacing them
+    #[arg(long = "keep")]
+    pub keep: bool,
+
+    /// Skip empty source values when combining
+    #[arg(long = "na-rm")]
+    pub na_rm: bool,
+
+    /// Treat input as headerless
+    #[arg(short = 'H', long = "no-header")]
+    pub no_header: bool,
+
+    #[arg(
+        short = 'C',
+        long = "comment-char",
+        value_name = "CHAR",
+        default_value = "#"
+    )]
+    pub comment_char: String,
+    #[arg(short = 'E', long = "ignore-empty-row")]
+    pub ignore_empty_row: bool,
+    #[arg(short = 'I', long = "ignore-illegal-row")]
+    pub ignore_illegal_row: bool,
+}
+
+pub fn run(args: UniteArgs) -> Result<()> {
+    let input_opts = InputOptions::from_flags(
+        &args.comment_char,
+        args.ignore_empty_row,
+        args.ignore_illegal_row,
+    )?;
+    let mut reader = reader_for_path(&args.file, args.no_header, &input_opts)?;
+    let mut writer = BufWriter::new(io::stdout().lock());
+
+    if args.no_header {
+        let mut records = reader.records();
+        let first_record = loop {
+            match records.next() {
+                Some(rec) => {
+                    let record =
+                        rec.with_context(|| format!("failed reading from {:?}", args.file))?;
+                    if should_skip_record(&record, &input_opts, None) {
+                        continue;
+                    }
+                    break record;
+                }
+                None => return Ok(()),
+            }
+        };
+        let expected_width = first_record.len();
+        let headers = default_headers(expected_width);
+        let selected = parse_selector_list(&args.fields)?;
+        let indices = resolve_selectors(&headers, &selected, true)?;
+        if indices.is_empty() {
+            bail!("--fields resolved to no columns");
+        }
+        let output_header = build_header(&headers, &indices, &args.name, args.keep);
+        writeln!(writer, "{}", output_header.join("\t"))?;
+        let row = unite_row(
+            first_record.iter().map(|s| s.to_string()).collect(),
+            &indices,
+            &args.name,
+            &args.sep,
+            args.keep,
+            args.na_rm,
+        );
+        writeln!(writer, "{}", row.join("\t"))?;
+        for record in records {
+            let record = record.with_context(|| format!("failed reading from {:?}", args.file))?;
+            if should_skip_record(&record, &input_opts, Some(expected_width)) {
+                continue;
+            }
+            let row = unite_row(
+                record.iter().map(|s| s.to_string()).collect(),
+                &indices,
+                &args.name,
+                &args.sep,
+                args.keep,
+                args.na_rm,
+            );
+            writeln!(writer, "{}", row.join("\t"))?;
+        }
+    } else {
+        let headers = reader
+            .headers()
+            .with_context(|| format!("failed reading header from {:?}", args.file))?
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        let expected_width = headers.len();
+        let selected = parse_selector_list(&args.fields)?;
+        let indices = resolve_selectors(&headers, &selected, false)?;
+        if indices.is_empty() {
+            bail!("--fields resolved to no columns");
+        }
+        let output_header = build_header(&headers, &indices, &args.name, args.keep);
+        writeln!(writer, "{}", output_header.join("\t"))?;
+        for record in reader.records() {
+            let record = record.with_context(|| format!("failed reading from {:?}", args.file))?;
+            if should_skip_record(&record, &input_opts, Some(expected_width)) {
+                continue;
+            }
+            let row = unite_row(
+                record.iter().map(|s| s.to_string()).collect(),
+                &indices,
+                &args.name,
+                &args.sep,
+                args.keep,
+                args.na_rm,
+            );
+            writeln!(writer, "{}", row.join("\t"))?;
+        }
+    }
+    writer.flush()?;
+    Ok(())
+}
+
+fn build_header(headers: &[String], indices: &[usize], name: &str, keep: bool) -> Vec<String> {
+    let selected: HashSet<usize> = indices.iter().copied().collect();
+    let first_selected = indices.iter().copied().min().unwrap_or(0);
+    let mut out = Vec::new();
+    for (idx, header) in headers.iter().enumerate() {
+        if idx == first_selected {
+            out.push(name.to_string());
+        }
+        if selected.contains(&idx) {
+            if keep {
+                out.push(header.clone());
+            }
+        } else {
+            out.push(header.clone());
+        }
+    }
+    out
+}
+
+fn unite_row(
+    row: Vec<String>,
+    indices: &[usize],
+    _name: &str,
+    sep: &str,
+    keep: bool,
+    na_rm: bool,
+) -> Vec<String> {
+    let selected: HashSet<usize> = indices.iter().copied().collect();
+    let first_selected = indices.iter().copied().min().unwrap_or(0);
+    let mut pieces = Vec::new();
+    for &idx in indices {
+        let text = row.get(idx).cloned().unwrap_or_default();
+        if na_rm && text.is_empty() {
+            continue;
+        }
+        pieces.push(text);
+    }
+    let combined = pieces.join(sep);
+    let mut out = Vec::new();
+    for (idx, value) in row.into_iter().enumerate() {
+        if idx == first_selected {
+            out.push(combined.clone());
+        }
+        if selected.contains(&idx) {
+            if keep {
+                out.push(value);
+            }
+        } else {
+            out.push(value);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unite_row_replaces_selected_columns() {
+        let row = vec!["s1".to_string(), "baseline".to_string(), "case".to_string()];
+        let out = unite_row(row, &[0, 1], "id", "_", false, false);
+        assert_eq!(out, vec!["s1_baseline", "case"]);
+    }
+
+    #[test]
+    fn unite_row_keep_and_na_rm() {
+        let row = vec!["A".to_string(), "".to_string(), "Z".to_string()];
+        let out = unite_row(row, &[0, 1], "id", "-", true, true);
+        assert_eq!(out, vec!["A", "A", "", "Z"]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Add ergonomics for header/column manipulation with `rename`, `separate`, and `unite` subcommands and document them in the README. 
- Improve safety and diagnostics in `filter` when expressions perform division so users are warned about rows with denominator exactly zero. 
- Make the CSV converter accept `-` (stdin) by default and bump the package version.

### Description
- Introduce three new subcommands implemented in `src/rename.rs`, `src/separate.rs`, and `src/unite.rs`, register them in `src/main.rs`, and document usage and examples in `README.md`. 
- Add expression evaluation diagnostics and denominator analysis in `src/expression.rs` with `EvalDiagnostics`, `evaluate_with_diagnostics`, `collect_division_denominator_columns`, and related helpers, and change division handling to record exact-zero denominators. 
- Update `src/filter.rs` to collect denominator columns, count rows whose denominator is exactly zero, use `evaluate_with_diagnostics` during evaluation, and emit a user-facing warning with a suggested guard expression. 
- Relax `csv` argument handling in `src/csv/mod.rs` to default input to `-`, update `Cargo.toml` version to `0.9.12` and refresh `Cargo.lock`, and add README entries for the new commands and the divide-by-zero note in `filter` docs.

### Testing
- Ran `cargo test` which executed unit tests including `division_keeps_non_zero_tiny_denominator`, `collects_division_denominator_columns`, and tests for `rename`, `separate`, and `unite`, and all tests passed. 
- Verified `filter` logic compiles and integrates the diagnostics path via the new `evaluate_with_diagnostics` API. 
- Confirmed the CLI builds and registers the new subcommands so `tsvkit rename`, `tsvkit separate`, and `tsvkit unite` are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24b7a0540832aaeb0c525e75f0024)