### PR TITLE
Add opt-in wildcard column selectors (-w/--wildcard) and support parsing/resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Selectors are reused in `cut`, `filter`, `join`, `mutate`, `summarize`, and othe
 | `-index` | Column counted from the end (1 = last). | `-1,-2` |
 | `start:end` | Inclusive range by name or index. Supports open ends. | `IL6:IL10`, `2:5`, `:IL10`, `IL6:` |
 | `~"regex"` | Columns whose names match the regular expression. Requires headers. | `~"^sample_"` |
+| `-w`/`--wildcard` + `*`/`.` | In `cut`, opt in to wildcard header matching (`*` = any text, `.` = any one character). | `-w -f '*col1,col2*,col3.'` |
 | `:` | Select every column in order. | `-f ':'` |
 | `mixed` | Combine names, indices, ranges, and regexes. | `sample_id,3:5,~"_pct$"` |
 | `multi-file` | Separate selectors for each input with semicolons (primarily `join`). | `sample_id;subject_id` |
@@ -140,7 +141,9 @@ Selectors are reused in `cut`, `filter`, `join`, `mutate`, `summarize`, and othe
 
 Negative indices are also valid inside ranges: `:-2` selects every column except the final two, while `-3:` keeps the last three columns. Regex selectors deduplicate by first match; add `--allow-dups` (or `-D`) on `cut`/`summarize` when you need repeated columns.
 
-> Regex selectors require a header row. When `-H/--no-header` is active, using `~"..."` results in an error with guidance to remove the regex or restore headers.
+Wildcard selectors are opt-in for `cut` so existing literal column names containing `*` or `.` continue to resolve exactly. With `-w`/`--wildcard`, unquoted `*` matches any text and unquoted `.` matches any single character; wrap a selector in backticks when you need a literal `*` or `.` in wildcard mode.
+
+> Regex and wildcard selectors require a header row. When `-H/--no-header` is active, using `~"..."` or `-w`/`--wildcard` patterns results in an error with guidance to remove the pattern selector or restore headers.
 
 Anywhere you access column *values* inside an expression, prefix the selector with `$` (`$purity`, `$1`, `$IL6:$IL10`).
 
@@ -252,6 +255,12 @@ Regex selectors pick up columns whose headers match a pattern. Combine them with
 
 ```bash
 tsvkit cut -f '1,group,~"^IL",~"_pct$"' examples/qc.tsv
+```
+
+Wildcard selectors are available behind `-w`/`--wildcard` for simpler header patterns. In this mode, `*` means “any text” and `.` means “any one character”:
+
+```bash
+tsvkit cut -w -f '*col1,col2*,col3.' data.tsv
 ```
 
 Injecting the source file basename (`__base__`) or filename with path (`__file__`):

--- a/src/common.rs
+++ b/src/common.rs
@@ -30,27 +30,36 @@ pub enum ColumnSelector {
     FromEnd(usize),
     Name(String),
     Regex(String),
+    Wildcard(String),
     Template(String),
     Range(Option<Box<ColumnSelector>>, Option<Box<ColumnSelector>>),
     Special(SpecialColumn),
 }
 
 pub fn parse_selector_list(spec: &str) -> Result<Vec<ColumnSelector>> {
-    parse_selector_list_impl(spec, false)
+    parse_selector_list_impl(spec, false, false)
 }
 
 pub fn parse_selector_list_with_templates(spec: &str) -> Result<Vec<ColumnSelector>> {
-    parse_selector_list_impl(spec, true)
+    parse_selector_list_impl(spec, true, false)
 }
 
-fn parse_selector_list_impl(spec: &str, braces_as_templates: bool) -> Result<Vec<ColumnSelector>> {
+pub fn parse_selector_list_with_templates_and_wildcards(spec: &str) -> Result<Vec<ColumnSelector>> {
+    parse_selector_list_impl(spec, true, true)
+}
+
+fn parse_selector_list_impl(
+    spec: &str,
+    braces_as_templates: bool,
+    wildcards_enabled: bool,
+) -> Result<Vec<ColumnSelector>> {
     if spec.trim().is_empty() {
         bail!("column specification must not be empty");
     }
 
     tokenize_selector_spec(spec)?
         .into_iter()
-        .map(|token| parse_selector_token(token, braces_as_templates))
+        .map(|token| parse_selector_token(token, braces_as_templates, wildcards_enabled))
         .collect()
 }
 
@@ -140,7 +149,8 @@ fn resolve_selectors_with_options(
             ColumnSelector::Index(_)
             | ColumnSelector::FromEnd(_)
             | ColumnSelector::Name(_)
-            | ColumnSelector::Regex(_) => {
+            | ColumnSelector::Regex(_)
+            | ColumnSelector::Wildcard(_) => {
                 let mut resolved =
                     resolve_selector_indices(headers, selector, no_header, allow_duplicates)?;
                 indices.append(&mut resolved);
@@ -515,7 +525,11 @@ fn capitalize_first(input: &str) -> String {
     }
 }
 
-fn parse_selector_token(token: SelectorToken, braces_as_templates: bool) -> Result<ColumnSelector> {
+fn parse_selector_token(
+    token: SelectorToken,
+    braces_as_templates: bool,
+    wildcards_enabled: bool,
+) -> Result<ColumnSelector> {
     if token.text.is_empty() {
         return Err(anyhow!("empty column selector"));
     }
@@ -535,6 +549,7 @@ fn parse_selector_token(token: SelectorToken, braces_as_templates: bool) -> Resu
             Some(Box::new(parse_simple_selector(
                 start_trim,
                 braces_as_templates,
+                false,
             )?))
         };
         let end_selector = if end_trim.is_empty() {
@@ -543,15 +558,20 @@ fn parse_selector_token(token: SelectorToken, braces_as_templates: bool) -> Resu
             Some(Box::new(parse_simple_selector(
                 end_trim,
                 braces_as_templates,
+                false,
             )?))
         };
         return Ok(ColumnSelector::Range(start_selector, end_selector));
     }
 
-    parse_simple_selector(&token.text, braces_as_templates)
+    parse_simple_selector(&token.text, braces_as_templates, wildcards_enabled)
 }
 
-fn parse_simple_selector(token: &str, braces_as_templates: bool) -> Result<ColumnSelector> {
+fn parse_simple_selector(
+    token: &str,
+    braces_as_templates: bool,
+    wildcards_enabled: bool,
+) -> Result<ColumnSelector> {
     if token.is_empty() {
         return Err(anyhow!("empty column selector"));
     }
@@ -590,7 +610,40 @@ fn parse_simple_selector(token: &str, braces_as_templates: bool) -> Result<Colum
         }
         return Ok(ColumnSelector::Index(idx - 1));
     }
+    if wildcards_enabled && contains_wildcard(token) {
+        return Ok(ColumnSelector::Wildcard(token.to_string()));
+    }
     Ok(ColumnSelector::Name(token.to_string()))
+}
+
+fn contains_wildcard(token: &str) -> bool {
+    if is_inline_template_like(token) {
+        return false;
+    }
+    token.contains('*') || token.contains('.')
+}
+
+fn is_inline_template_like(token: &str) -> bool {
+    token
+        .split_once('=')
+        .map(|(_, rhs)| {
+            let rhs = rhs.trim();
+            rhs.starts_with('{') && rhs.ends_with('}')
+        })
+        .unwrap_or(false)
+}
+
+fn wildcard_pattern_to_regex(pattern: &str) -> String {
+    let mut regex = String::from("^");
+    for ch in pattern.chars() {
+        match ch {
+            '*' => regex.push_str(".*"),
+            '.' => regex.push('.'),
+            other => regex.push_str(&regex::escape(&other.to_string())),
+        }
+    }
+    regex.push('$');
+    regex
 }
 
 fn parse_regex_literal(token: &str) -> Result<Option<String>> {
@@ -840,6 +893,36 @@ fn tokenize_selector_spec(spec: &str) -> Result<Vec<SelectorToken>> {
     Ok(tokens)
 }
 
+fn resolve_pattern_selector(
+    headers: &[String],
+    no_header: bool,
+    allow_duplicates: bool,
+    regex_pattern: &str,
+    display_pattern: &str,
+    selector_kind: &str,
+) -> Result<Vec<usize>> {
+    if no_header {
+        bail!("{} column selectors require headers", selector_kind);
+    }
+    let regex = Regex::new(regex_pattern)
+        .with_context(|| format!("invalid {} pattern '{}'", selector_kind, display_pattern))?;
+    let mut seen = HashSet::new();
+    let mut matches = Vec::new();
+    for (idx, header) in headers.iter().enumerate() {
+        if regex.is_match(header) && (allow_duplicates || seen.insert(header.clone())) {
+            matches.push(idx);
+        }
+    }
+    if matches.is_empty() {
+        bail!(
+            "{} pattern '{}' did not match any columns",
+            selector_kind,
+            display_pattern
+        );
+    }
+    Ok(matches)
+}
+
 fn resolve_selector_indices(
     headers: &[String],
     selector: &ColumnSelector,
@@ -895,25 +978,24 @@ fn resolve_selector_indices(
                 Ok(vec![index])
             }
         }
-        ColumnSelector::Regex(pattern) => {
-            if no_header {
-                bail!("regex column selectors require headers");
-            }
-            let regex = Regex::new(pattern)
-                .with_context(|| format!("invalid regex pattern '{}'", pattern))?;
-            let mut seen = HashSet::new();
-            let mut matches = Vec::new();
-            for (idx, header) in headers.iter().enumerate() {
-                if regex.is_match(header) {
-                    if allow_duplicates || seen.insert(header.clone()) {
-                        matches.push(idx);
-                    }
-                }
-            }
-            if matches.is_empty() {
-                bail!("regex pattern '{}' did not match any columns", pattern);
-            }
-            Ok(matches)
+        ColumnSelector::Regex(pattern) => resolve_pattern_selector(
+            headers,
+            no_header,
+            allow_duplicates,
+            pattern,
+            pattern,
+            "regex",
+        ),
+        ColumnSelector::Wildcard(pattern) => {
+            let regex_pattern = wildcard_pattern_to_regex(pattern);
+            resolve_pattern_selector(
+                headers,
+                no_header,
+                allow_duplicates,
+                &regex_pattern,
+                pattern,
+                "wildcard",
+            )
         }
         ColumnSelector::Template(template) => bail!(
             "template selector '{{{}}}' cannot be resolved as a positional index",
@@ -971,6 +1053,9 @@ fn resolve_selector_index(
         ColumnSelector::Regex(_) => {
             bail!("regex column selectors cannot be used in range endpoints")
         }
+        ColumnSelector::Wildcard(_) => {
+            bail!("wildcard column selectors cannot be used in range endpoints")
+        }
         ColumnSelector::Template(template) => {
             bail!(
                 "template selector '{{{}}}' cannot be used in range endpoints",
@@ -998,9 +1083,10 @@ mod tests {
     use xz2::write::XzEncoder;
 
     use super::{
-        ColumnSelector, FileTemplateContext, SpecialColumn, parse_selector_list,
-        open_path_reader, parse_selector_list_with_templates, parse_single_selector,
-        render_file_template, resolve_selectors, resolve_selectors_allow_duplicates,
+        ColumnSelector, FileTemplateContext, SpecialColumn, open_path_reader, parse_selector_list,
+        parse_selector_list_with_templates, parse_selector_list_with_templates_and_wildcards,
+        parse_single_selector, render_file_template, resolve_selectors,
+        resolve_selectors_allow_duplicates,
     };
 
     #[test]
@@ -1162,6 +1248,45 @@ mod tests {
         ));
         assert!(matches!(selectors[1], ColumnSelector::Name(ref name) if name == "__file__"));
         assert!(matches!(selectors[2], ColumnSelector::Name(ref name) if name == "__base__"));
+    }
+
+    #[test]
+    fn wildcard_selectors_match_headers_when_enabled() {
+        let headers = vec![
+            "alpha_col1".to_string(),
+            "col2_a".to_string(),
+            "col2_b".to_string(),
+            "col3x".to_string(),
+            "col3xy".to_string(),
+        ];
+        let selectors =
+            parse_selector_list_with_templates_and_wildcards("*col1,col2*,col3.").unwrap();
+        assert!(
+            matches!(selectors[0], ColumnSelector::Wildcard(ref pattern) if pattern == "*col1")
+        );
+        let indices = resolve_selectors(&headers, &selectors, false).unwrap();
+        assert_eq!(indices, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn wildcard_mode_preserves_quoted_literals() {
+        let selectors = parse_selector_list_with_templates_and_wildcards("`a.b`,{c*d}").unwrap();
+        assert!(matches!(selectors[0], ColumnSelector::Name(ref name) if name == "a.b"));
+        assert!(
+            matches!(selectors[1], ColumnSelector::Template(ref template) if template == "c*d")
+        );
+    }
+
+    #[test]
+    fn wildcard_mode_preserves_inline_templates() {
+        let selectors = parse_selector_list_with_templates_and_wildcards("sample={base.}").unwrap();
+        assert!(matches!(selectors[0], ColumnSelector::Name(ref name) if name == "sample={base.}"));
+    }
+
+    #[test]
+    fn wildcard_characters_are_literal_without_wildcard_mode() {
+        let selectors = parse_selector_list_with_templates("a.b").unwrap();
+        assert!(matches!(selectors[0], ColumnSelector::Name(ref name) if name == "a.b"));
     }
 
     #[test]

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -6,8 +6,9 @@ use clap::Args;
 
 use crate::common::{
     ColumnSelector, FileTemplateContext, InputOptions, SpecialColumn, default_headers,
-    parse_selector_list_with_templates, reader_for_path, render_file_template, resolve_selectors,
-    resolve_selectors_allow_duplicates, should_skip_record,
+    parse_selector_list_with_templates, parse_selector_list_with_templates_and_wildcards,
+    reader_for_path, render_file_template, resolve_selectors, resolve_selectors_allow_duplicates,
+    should_skip_record,
 };
 
 #[derive(Args, Debug)]
@@ -15,6 +16,7 @@ use crate::common::{
     about = "Select and reorder TSV columns",
     after_help = "Selector syntax:
   name,index,range,regex mix:  id,2,group:tech,~\"^IL\"
+  opt-in wildcards:           -w -f '*col1,col2*,col3.'
   negative indices/ranges:     -1,-2:     (last column, second-last to end)
   literal symbol names:        `2:4`      (avoid selector parsing)
 
@@ -50,10 +52,12 @@ Examples:
   tsvkit cut -H -f '3,1,-1' data.tsv
   tsvkit cut -C ';' -E -I -f '1:3' dirty.tsv
   tsvkit cut -D -f 'value,~\"^value$\"' duplicated_headers.tsv
+  tsvkit cut -w -f '*col1,col2*,col3.' data.tsv
 
 Practical tips:
   - Use -f first, then pipe into filter/summarize/sort for analysis workflows.
   - Use regex selectors (~\"...\") to keep evolving column groups (e.g. assays).
+  - Use -w/--wildcard only when you want '*' (any text) and '.' (any one char) in names to match patterns.
   - Use template/injected selectors to preserve provenance when concatenating files."
 )]
 pub struct CutArgs {
@@ -100,13 +104,21 @@ pub struct CutArgs {
     #[arg(short = 'I', long = "ignore-illegal-row")]
     pub ignore_illegal_row: bool,
 
-    /// Allow duplicate column matches when resolving names or regex selectors
+    /// Allow duplicate column matches when resolving names, regex selectors, or wildcard selectors
     #[arg(short = 'D', long = "allow-dups")]
     pub allow_dups: bool,
+
+    /// Interpret unquoted '*' and '.' in field names as wildcard pattern characters ('*' = any text, '.' = any one character)
+    #[arg(short = 'w', long = "wildcard", visible_alias = "wildcards")]
+    pub wildcard: bool,
 }
 
 pub fn run(args: CutArgs) -> Result<()> {
-    let selectors = parse_selector_list_with_templates(&args.fields)?;
+    let selectors = if args.wildcard {
+        parse_selector_list_with_templates_and_wildcards(&args.fields)?
+    } else {
+        parse_selector_list_with_templates(&args.fields)?
+    };
     let input_opts = InputOptions::from_flags(
         &args.comment_char,
         args.ignore_empty_row,


### PR DESCRIPTION
### Motivation
- Provide an opt-in, simple wildcard syntax (`*` = any text, `.` = any one character) for header matching while preserving existing literal behavior for `*` and `.` in selectors. 
- Keep regex selectors and template/injected selectors working unchanged and ensure wildcard behavior only applies when explicitly enabled.

### Description
- Introduces a new `ColumnSelector::Wildcard` variant and adds `parse_selector_list_with_templates_and_wildcards` to enable wildcard-aware parsing.
- Extends the selector parser to accept a `wildcards_enabled` flag, adds `contains_wildcard`, `is_inline_template_like`, and `wildcard_pattern_to_regex` helpers, and treats inline templates/quoted literals as literals in wildcard mode.
- Implements `resolve_pattern_selector` to unify header matching logic for regex and wildcard selectors and returns helpful errors when headers are missing or no matches are found; wildcard selectors are disallowed as range endpoints with a clear error.
- Adds a `-w/--wildcard` flag to `tsvkit cut` and wires parsing to use the wildcard-enabled parser when the flag is provided, and updates help text and `README.md` documentation to explain the opt-in wildcard semantics and examples.

### Testing
- Ran the unit test suite with `cargo test`, including new tests `wildcard_selectors_match_headers_when_enabled`, `wildcard_mode_preserves_quoted_literals`, `wildcard_mode_preserves_inline_templates`, and `wildcard_characters_are_literal_without_wildcard_mode`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a295dffc678832a9763ae9a07eed55d)